### PR TITLE
Prepare for first release

### DIFF
--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -93,42 +93,43 @@ jobs:
           - { target: x86_64-unknown-linux-gnu, arch: amd64, os: ubuntu-20.04 }
           - { target: x86_64-apple-darwin, arch: darwin, os: macos-latest }
           - { target: aarch64-apple-darwin, arch: darwin, os: macos-latest }
-          # - {
-          #     target: x86_64-unknown-linux-musl,
-          #     arch: amd64,
-          #     os: ubuntu-20.04,
-          #     use-cross: true,
-          #   }
-          # - {
-          #     target: arm-unknown-linux-gnueabi,
-          #     arch: armel,
-          #     os: ubuntu-20.04,
-          #     use-cross: true,
-          #   }
+          - {
+              target: x86_64-unknown-linux-musl,
+              arch: amd64,
+              os: ubuntu-20.04,
+              use-cross: true,
+            }
+          - {
+              target: arm-unknown-linux-gnueabi,
+              arch: armel,
+              os: ubuntu-20.04,
+              use-cross: true,
+            }
           - {
               target: arm-unknown-linux-gnueabihf,
               arch: armhf,
               os: ubuntu-20.04,
               use-cross: true,
             }
-          # - {
-          #     target: armv7-unknown-linux-gnueabihf,
-          #     arch: armhf,
-          #     os: ubuntu-20.04,
-          #     use-cross: true,
-          #   }
-          # - {
-          #     target: aarch64-unknown-linux-gnu,
-          #     arch: arm64,
-          #     os: ubuntu-20.04,
-          #     use-cross: true,
-          #   }
-          # - {
-          #     target: aarch64-unknown-linux-musl,
-          #     arch: arm64,
-          #     os: ubuntu-20.04,
-          #     use-cross: true,
-          #   }
+          - {
+              target: armv7-unknown-linux-gnueabihf,
+              arch: armhf,
+              os: ubuntu-20.04,
+              use-cross: true,
+            }
+          - {
+              target: aarch64-unknown-linux-gnu,
+              arch: arm64,
+              os: ubuntu-20.04,
+              use-cross: true,
+            }
+          - {
+              target: aarch64-unknown-linux-musl,
+              arch: arm64,
+              os: ubuntu-20.04,
+              use-cross: true,
+            }
+          # win is possible to build on, but we don't target it for now
           # - { target: x86_64-pc-windows-msvc, arch: win64, os: windows-2019 }
           # - { target: x86_64-pc-windows-gnu         , arch: win64 , os: windows-2019                  }
     steps:

--- a/Cargo.lock
+++ b/Cargo.lock
@@ -56,9 +56,9 @@ dependencies = [
 
 [[package]]
 name = "aho-corasick"
-version = "1.0.4"
+version = "1.0.5"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "6748e8def348ed4d14996fa801f4122cd763fff530258cdc03f64b25f89d3a5a"
+checksum = "0c378d78423fdad8089616f827526ee33c19f2fddbd5de1629152c9593ba4783"
 dependencies = [
  "memchr",
 ]
@@ -261,7 +261,7 @@ checksum = "bc00ceb34980c03614e35a3a4e218276a0a824e911d07651cd0d858a51e8c0f0"
 dependencies = [
  "proc-macro2",
  "quote",
- "syn 2.0.29",
+ "syn 2.0.32",
 ]
 
 [[package]]
@@ -339,9 +339,9 @@ checksum = "9e1b586273c5702936fe7b7d6896644d8be71e6314cfe09d3167c95f712589e8"
 
 [[package]]
 name = "base64"
-version = "0.21.2"
+version = "0.21.4"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "604178f6c5c21f02dc555784810edfb88d34ac2c73b2eae109655649ee73ce3d"
+checksum = "9ba43ea6f343b788c8764558649e08df62f86c6ef251fdaeb1ffd010a9ae50a2"
 
 [[package]]
 name = "base64ct"
@@ -460,9 +460,9 @@ checksum = "14c189c53d098945499cdfa7ecc63567cf3886b3332b312a5b4585d8d3a6a610"
 
 [[package]]
 name = "bytes"
-version = "1.4.0"
+version = "1.5.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "89b2fd2a0dcf38d7971e2194b6b6eebab45ae01067456a7fd93d5547a61b70be"
+checksum = "a2bd12c1caf447e69cd4528f47f94d203fd2582878ecb9e9465484c4148a8223"
 
 [[package]]
 name = "cache-padded"
@@ -487,14 +487,14 @@ checksum = "baf1de4339761588bc0619e3cbc0120ee582ebb74b53b4efbf79117bd2da40fd"
 
 [[package]]
 name = "chrono"
-version = "0.4.26"
+version = "0.4.30"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "ec837a71355b28f6556dbd569b37b3f363091c0bd4b2e735674521b4c5fd9bc5"
+checksum = "defd4e7873dbddba6c7c91e199c7fcb946abc4a6a4ac3195400bcfb01b5de877"
 dependencies = [
  "android-tzdata",
  "iana-time-zone",
  "num-traits",
- "winapi",
+ "windows-targets",
 ]
 
 [[package]]
@@ -696,19 +696,19 @@ dependencies = [
 
 [[package]]
 name = "ctrlc"
-version = "3.4.0"
+version = "3.4.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "2a011bbe2c35ce9c1f143b7af6f94f29a167beb4cd1d29e6740ce836f723120e"
+checksum = "82e95fbd621905b854affdc67943b043a0fbb6ed7385fd5a25650d19a8a6cfdf"
 dependencies = [
- "nix",
+ "nix 0.27.1",
  "windows-sys",
 ]
 
 [[package]]
 name = "dashmap"
-version = "5.5.1"
+version = "5.5.3"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "edd72493923899c6f10c641bdbdeddc7183d6396641d99c1a0d1597f37f92e28"
+checksum = "978747c1d849a7d2ee5e8adc0159961c48fb7e5db2f06af6723b80123bb53856"
 dependencies = [
  "cfg-if",
  "hashbrown 0.14.0",
@@ -813,7 +813,7 @@ dependencies = [
  "atty",
  "humantime",
  "log 0.4.20",
- "regex 1.9.3",
+ "regex 1.9.5",
  "termcolor",
 ]
 
@@ -826,7 +826,7 @@ dependencies = [
  "humantime",
  "is-terminal",
  "log 0.4.20",
- "regex 1.9.3",
+ "regex 1.9.5",
  "termcolor",
 ]
 
@@ -838,9 +838,9 @@ checksum = "5443807d6dff69373d433ab9ef5378ad8df50ca6298caf15de6e52e24aaf54d5"
 
 [[package]]
 name = "errno"
-version = "0.3.2"
+version = "0.3.3"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "6b30f669a7961ef1631673d2766cc92f52d64f7ef354d4fe0ddfd30ed52f0f4f"
+checksum = "136526188508e25c6fef639d7927dfb3e0e3084488bf202267829cf7fc23dbdd"
 dependencies = [
  "errno-dragonfly",
  "libc",
@@ -1020,7 +1020,7 @@ checksum = "89ca545a94061b6365f2c7355b4b32bd20df3ff95f02da9329b34ccc3bd6ee72"
 dependencies = [
  "proc-macro2",
  "quote",
- "syn 2.0.29",
+ "syn 2.0.32",
 ]
 
 [[package]]
@@ -1365,7 +1365,7 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "cb0889898416213fab133e1d33a0e5858a48177452750691bde3666d0fdbaf8b"
 dependencies = [
  "hermit-abi 0.3.2",
- "rustix 0.38.8",
+ "rustix 0.38.13",
  "windows-sys",
 ]
 
@@ -1482,9 +1482,9 @@ checksum = "ef53942eb7bf7ff43a617b3e2c1c4a5ecf5944a7c1bc12d7ee39bbb15e5c1519"
 
 [[package]]
 name = "linux-raw-sys"
-version = "0.4.5"
+version = "0.4.7"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "57bcfdad1b858c2db7c38303a6d2ad4dfaf5eb53dfeb0910128b2c26d6158503"
+checksum = "1a9bad9f94746442c783ca431b22403b519cd7fbeed0533fdd6328b2f2212128"
 
 [[package]]
 name = "lock_api"
@@ -1548,9 +1548,9 @@ dependencies = [
 
 [[package]]
 name = "memchr"
-version = "2.5.0"
+version = "2.6.3"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "2dffe52ecf27772e601905b7522cb4ef790d2cc203488bbd0e2fe85fcb74566d"
+checksum = "8f232d6ef707e1956a43342693d2a31e72989554d58299d7a88738cc95b0d35c"
 
 [[package]]
 name = "memoffset"
@@ -1650,16 +1650,26 @@ dependencies = [
 
 [[package]]
 name = "nix"
-version = "0.26.2"
+version = "0.26.4"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "bfdda3d196821d6af13126e40375cdf7da646a96114af134d5f417a9a1dc8e1a"
+checksum = "598beaf3cc6fdd9a5dfb1630c2800c7acd31df7aaf0f565796fba2b53ca1af1b"
 dependencies = [
  "bitflags 1.3.2",
  "cfg-if",
  "libc",
  "memoffset 0.7.1",
  "pin-utils",
- "static_assertions",
+]
+
+[[package]]
+name = "nix"
+version = "0.27.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "2eb04e9c688eff1c89d72b407f168cf79bb9e867a9d3323ed6c01519eb9cc053"
+dependencies = [
+ "bitflags 2.4.0",
+ "cfg-if",
+ "libc",
 ]
 
 [[package]]
@@ -1737,9 +1747,9 @@ dependencies = [
 
 [[package]]
 name = "object"
-version = "0.32.0"
+version = "0.32.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "77ac5bbd07aea88c60a577a1ce218075ffd59208b2d7ca97adf9bfc5aeb21ebe"
+checksum = "9cf5f9dd3933bd50a9e1f149ec995f39ae2c496d31fd772c1fd45ebc27e902b0"
 dependencies = [
  "memchr",
 ]
@@ -1841,19 +1851,20 @@ checksum = "9b2a4787296e9989611394c33f193f676704af1686e70b8f8033ab5ba9a35a94"
 
 [[package]]
 name = "pest"
-version = "2.7.2"
+version = "2.7.3"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "1acb4a4365a13f749a93f1a094a7805e5cfa0955373a9de860d962eaa3a5fe5a"
+checksum = "d7a4d085fd991ac8d5b05a147b437791b4260b76326baf0fc60cf7c9c27ecd33"
 dependencies = [
+ "memchr",
  "thiserror",
  "ucd-trie",
 ]
 
 [[package]]
 name = "pest_derive"
-version = "2.7.2"
+version = "2.7.3"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "666d00490d4ac815001da55838c500eafb0320019bbaa44444137c48b443a853"
+checksum = "a2bee7be22ce7918f641a33f08e3f43388c7656772244e2bbb2477f44cc9021a"
 dependencies = [
  "pest",
  "pest_generator",
@@ -1861,22 +1872,22 @@ dependencies = [
 
 [[package]]
 name = "pest_generator"
-version = "2.7.2"
+version = "2.7.3"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "68ca01446f50dbda87c1786af8770d535423fa8a53aec03b8f4e3d7eb10e0929"
+checksum = "d1511785c5e98d79a05e8a6bc34b4ac2168a0e3e92161862030ad84daa223141"
 dependencies = [
  "pest",
  "pest_meta",
  "proc-macro2",
  "quote",
- "syn 2.0.29",
+ "syn 2.0.32",
 ]
 
 [[package]]
 name = "pest_meta"
-version = "2.7.2"
+version = "2.7.3"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "56af0a30af74d0445c0bf6d9d051c979b516a1a5af790d251daee76005420a48"
+checksum = "b42f0394d3123e33353ca5e1e89092e533d2cc490389f2bd6131c43c634ebc5f"
 dependencies = [
  "once_cell",
  "pest",
@@ -1910,14 +1921,14 @@ checksum = "4359fd9c9171ec6e8c62926d6faaf553a8dc3f64e1507e76da7911b4f6a04405"
 dependencies = [
  "proc-macro2",
  "quote",
- "syn 2.0.29",
+ "syn 2.0.32",
 ]
 
 [[package]]
 name = "pin-project-lite"
-version = "0.2.12"
+version = "0.2.13"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "12cc1b0bf1727a77a54b6654e7b5f1af8604923edc8b81885f8ec92f9e3f0a05"
+checksum = "8afb450f006bf6385ca15ef45d71d2288452bc3683ce2e2cacc0d18e4be60b58"
 
 [[package]]
 name = "pin-utils"
@@ -1991,7 +2002,7 @@ checksum = "2a780e80005c2e463ec25a6e9f928630049a10b43945fea83207207d4a7606f4"
 dependencies = [
  "proc-macro2",
  "quote",
- "regex 1.9.3",
+ "regex 1.9.5",
  "syn 1.0.109",
 ]
 
@@ -2212,25 +2223,25 @@ dependencies = [
 
 [[package]]
 name = "regex"
-version = "1.9.3"
+version = "1.9.5"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "81bc1d4caf89fac26a70747fe603c130093b53c773888797a6329091246d651a"
+checksum = "697061221ea1b4a94a624f67d0ae2bfe4e22b8a17b6a192afb11046542cc8c47"
 dependencies = [
- "aho-corasick 1.0.4",
+ "aho-corasick 1.0.5",
  "memchr",
  "regex-automata",
- "regex-syntax 0.7.4",
+ "regex-syntax 0.7.5",
 ]
 
 [[package]]
 name = "regex-automata"
-version = "0.3.6"
+version = "0.3.8"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "fed1ceff11a1dddaee50c9dc8e4938bd106e9d89ae372f192311e7da498e3b69"
+checksum = "c2f401f4955220693b56f8ec66ee9c78abffd8d1c4f23dc41a23839eb88f0795"
 dependencies = [
- "aho-corasick 1.0.4",
+ "aho-corasick 1.0.5",
  "memchr",
- "regex-syntax 0.7.4",
+ "regex-syntax 0.7.5",
 ]
 
 [[package]]
@@ -2244,9 +2255,9 @@ dependencies = [
 
 [[package]]
 name = "regex-syntax"
-version = "0.7.4"
+version = "0.7.5"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "e5ea92a5b6195c6ef2a0295ea818b312502c6fc94dde986c5553242e18fd4ce2"
+checksum = "dbb5fb1acd8a1a18b3dd5be62d25485eb770e05afb408a9627d14d451bae12da"
 
 [[package]]
 name = "ring"
@@ -2275,15 +2286,15 @@ dependencies = [
 
 [[package]]
 name = "ros_message"
-version = "0.1.0"
-source = "git+https://github.com/ZettaScaleLabs/rosrust.git?branch=feature/fix_bugs#3ff335ae909e494578d2c9b5d020c5ade58f39cf"
+version = "0.1.1"
+source = "git+https://github.com/ZettaScaleLabs/rosrust.git?branch=feature/fix_bugs#e21ec5b0b6c50e5fe8dc032e12f60142056643bf"
 dependencies = [
  "array-init",
  "hex",
  "itertools",
  "lazy_static",
  "md-5",
- "regex 1.9.3",
+ "regex 1.9.5",
  "serde",
  "serde_derive",
  "thiserror",
@@ -2291,8 +2302,8 @@ dependencies = [
 
 [[package]]
 name = "rosrust"
-version = "0.9.10"
-source = "git+https://github.com/ZettaScaleLabs/rosrust.git?branch=feature/fix_bugs#3ff335ae909e494578d2c9b5d020c5ade58f39cf"
+version = "0.9.11"
+source = "git+https://github.com/ZettaScaleLabs/rosrust.git?branch=feature/fix_bugs#e21ec5b0b6c50e5fe8dc032e12f60142056643bf"
 dependencies = [
  "byteorder",
  "colored",
@@ -2302,7 +2313,7 @@ dependencies = [
  "hostname",
  "lazy_static",
  "log 0.4.20",
- "regex 1.9.3",
+ "regex 1.9.5",
  "ros_message",
  "rosrust_codegen",
  "serde",
@@ -2315,7 +2326,7 @@ dependencies = [
 [[package]]
 name = "rosrust_codegen"
 version = "0.9.6"
-source = "git+https://github.com/ZettaScaleLabs/rosrust.git?branch=feature/fix_bugs#3ff335ae909e494578d2c9b5d020c5ade58f39cf"
+source = "git+https://github.com/ZettaScaleLabs/rosrust.git?branch=feature/fix_bugs#e21ec5b0b6c50e5fe8dc032e12f60142056643bf"
 dependencies = [
  "error-chain 0.12.4",
  "hex",
@@ -2346,9 +2357,9 @@ dependencies = [
  "serde_json",
  "sha1_smol",
  "threadpool",
- "time 0.3.27",
+ "time 0.3.28",
  "tiny_http",
- "url 2.4.0",
+ "url 2.4.1",
 ]
 
 [[package]]
@@ -2408,22 +2419,22 @@ dependencies = [
 
 [[package]]
 name = "rustix"
-version = "0.38.8"
+version = "0.38.13"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "19ed4fa021d81c8392ce04db050a3da9a60299050b7ae1cf482d862b54a7218f"
+checksum = "d7db8590df6dfcd144d22afd1b83b36c21a18d7cbc1dc4bb5295a8712e9eb662"
 dependencies = [
  "bitflags 2.4.0",
  "errno",
  "libc",
- "linux-raw-sys 0.4.5",
+ "linux-raw-sys 0.4.7",
  "windows-sys",
 ]
 
 [[package]]
 name = "rustls"
-version = "0.21.6"
+version = "0.21.7"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "1d1feddffcfcc0b33f5c6ce9a29e341e4cd59c3f78e7ee45f4a40c038b1d6cbb"
+checksum = "cd8d6c9f025a446bc4d18ad9632e69aec8f287aa84499ee335599fabd20c3fd8"
 dependencies = [
  "log 0.4.20",
  "ring",
@@ -2449,7 +2460,7 @@ version = "1.0.3"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "2d3987094b1d07b653b7dfdc3f70ce9a1da9c51ac18c1b06b662e4f9a0e9f4b2"
 dependencies = [
- "base64 0.21.2",
+ "base64 0.21.4",
 ]
 
 [[package]]
@@ -2497,9 +2508,9 @@ dependencies = [
 
 [[package]]
 name = "schemars"
-version = "0.8.12"
+version = "0.8.13"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "02c613288622e5f0c3fdc5dbd4db1c5fbe752746b1d1a56a0630b78fd00de44f"
+checksum = "763f8cd0d4c71ed8389c90cb8100cba87e763bd01a8e614d4f0af97bcd50a161"
 dependencies = [
  "dyn-clone",
  "schemars_derive",
@@ -2509,9 +2520,9 @@ dependencies = [
 
 [[package]]
 name = "schemars_derive"
-version = "0.8.12"
+version = "0.8.13"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "109da1e6b197438deb6db99952990c7f959572794b80ff93707d55a232545e7c"
+checksum = "ec0f696e21e10fa546b7ffb1c9672c6de8fbc7a81acf59524386d8639bf12737"
 dependencies = [
  "proc-macro2",
  "quote",
@@ -2566,9 +2577,9 @@ checksum = "b0293b4b29daaf487284529cc2f5675b8e57c61f70167ba415a463651fd6a918"
 
 [[package]]
 name = "serde"
-version = "1.0.186"
+version = "1.0.188"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "9f5db24220c009de9bd45e69fb2938f4b6d2df856aa9304ce377b3180f83b7c1"
+checksum = "cf9e0fcba69a370eed61bcf2b728575f726b50b55cba78064753d708ddc7549e"
 dependencies = [
  "serde_derive",
 ]
@@ -2595,13 +2606,13 @@ dependencies = [
 
 [[package]]
 name = "serde_derive"
-version = "1.0.186"
+version = "1.0.188"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "5ad697f7e0b65af4983a4ce8f56ed5b357e8d3c36651bf6a7e13639c17b8e670"
+checksum = "4eca7ac642d82aa35b60049a6eccb4be6be75e599bd2e9adb5f875a737654af2"
 dependencies = [
  "proc-macro2",
  "quote",
- "syn 2.0.29",
+ "syn 2.0.32",
 ]
 
 [[package]]
@@ -2617,9 +2628,9 @@ dependencies = [
 
 [[package]]
 name = "serde_json"
-version = "1.0.105"
+version = "1.0.106"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "693151e1ac27563d6dbcec9dee9fbd5da8539b20fa14ad3752b2e6d363ace360"
+checksum = "2cc66a619ed80bf7a0f6b17dd063a84b88f6dea1813737cf469aef1d081142c2"
 dependencies = [
  "itoa",
  "ryu",
@@ -2862,9 +2873,9 @@ dependencies = [
 
 [[package]]
 name = "syn"
-version = "2.0.29"
+version = "2.0.32"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "c324c494eba9d92503e6f1ef2e6df781e78f6a7705a0202d9801b198807d518a"
+checksum = "239814284fd6f1a4ffe4ca893952cdd93c224b6a1571c9a9eadd670295c0c9e2"
 dependencies = [
  "proc-macro2",
  "quote",
@@ -2880,7 +2891,7 @@ dependencies = [
  "cfg-if",
  "fastrand 2.0.0",
  "redox_syscall 0.3.5",
- "rustix 0.38.8",
+ "rustix 0.38.13",
  "windows-sys",
 ]
 
@@ -2901,22 +2912,22 @@ checksum = "222a222a5bfe1bba4a77b45ec488a741b3cb8872e5e499451fd7d0129c9c7c3d"
 
 [[package]]
 name = "thiserror"
-version = "1.0.47"
+version = "1.0.48"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "97a802ec30afc17eee47b2855fc72e0c4cd62be9b4efe6591edde0ec5bd68d8f"
+checksum = "9d6d7a740b8a666a7e828dd00da9c0dc290dff53154ea77ac109281de90589b7"
 dependencies = [
  "thiserror-impl",
 ]
 
 [[package]]
 name = "thiserror-impl"
-version = "1.0.47"
+version = "1.0.48"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "6bb623b56e39ab7dcd4b1b98bb6c8f8d907ed255b18de254088016b27a8ee19b"
+checksum = "49922ecae66cc8a249b77e68d1d0623c1b2c514f0060c27cdc68bd62a1219d35"
 dependencies = [
  "proc-macro2",
  "quote",
- "syn 2.0.29",
+ "syn 2.0.32",
 ]
 
 [[package]]
@@ -2950,9 +2961,9 @@ dependencies = [
 
 [[package]]
 name = "time"
-version = "0.3.27"
+version = "0.3.28"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "0bb39ee79a6d8de55f48f2293a830e040392f1c5f16e336bdd1788cd0aadce07"
+checksum = "17f6bb557fd245c28e6411aa56b6403c689ad95061f50e4be16c274e70a17e48"
 dependencies = [
  "deranged",
  "libc",
@@ -3028,7 +3039,7 @@ checksum = "630bdcf245f78637c13ec01ffae6187cca34625e8c63150d424b59e55af2675e"
 dependencies = [
  "proc-macro2",
  "quote",
- "syn 2.0.29",
+ "syn 2.0.32",
 ]
 
 [[package]]
@@ -3064,7 +3075,7 @@ checksum = "5f4f31f56159e98206da9efd823404b79b6ef3143b4a7ab76e67b1751b25a4ab"
 dependencies = [
  "proc-macro2",
  "quote",
- "syn 2.0.29",
+ "syn 2.0.32",
 ]
 
 [[package]]
@@ -3097,7 +3108,7 @@ dependencies = [
  "rand",
  "sha1",
  "thiserror",
- "url 2.4.0",
+ "url 2.4.1",
  "utf-8",
 ]
 
@@ -3146,11 +3157,10 @@ checksum = "abd2fc5d32b590614af8b0a20d837f32eca055edd0bbead59a9cfe80858be003"
 
 [[package]]
 name = "uhlc"
-version = "0.6.0"
+version = "0.6.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "af1438496174a601a35fb41bf9bc408e47384b1df52ddc1252e75ef0ab811322"
+checksum = "91fd883bd1822917d4fcdff9bc1086f7fcf97c84ef6736185f6e1ff4c15da884"
 dependencies = [
- "hex",
  "humantime",
  "lazy_static",
  "log 0.4.20",
@@ -3240,9 +3250,9 @@ dependencies = [
 
 [[package]]
 name = "url"
-version = "2.4.0"
+version = "2.4.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "50bff7831e19200a85b17131d085c25d7811bc4e186efdaf54bbd132994a88cb"
+checksum = "143b538f18257fac9cad154828a57c6bf5157e1aa604d4816b5995bf6de87ae5"
 dependencies = [
  "form_urlencoded",
  "idna 0.4.0",
@@ -3357,7 +3367,7 @@ dependencies = [
  "once_cell",
  "proc-macro2",
  "quote",
- "syn 2.0.29",
+ "syn 2.0.32",
  "wasm-bindgen-shared",
 ]
 
@@ -3391,7 +3401,7 @@ checksum = "54681b18a46765f095758388f2d0cf16eb8d4169b639ab575a8f5693af210c7b"
 dependencies = [
  "proc-macro2",
  "quote",
- "syn 2.0.29",
+ "syn 2.0.32",
  "wasm-bindgen-backend",
  "wasm-bindgen-shared",
 ]
@@ -3579,7 +3589,7 @@ dependencies = [
  "async-global-executor",
  "async-std",
  "async-trait",
- "base64 0.21.2",
+ "base64 0.21.4",
  "env_logger 0.10.0",
  "event-listener",
  "flume",
@@ -3593,7 +3603,7 @@ dependencies = [
  "paste",
  "petgraph",
  "rand",
- "regex 1.9.3",
+ "regex 1.9.5",
  "rustc_version",
  "serde",
  "serde_json",
@@ -3860,7 +3870,7 @@ dependencies = [
  "async-trait",
  "futures 0.3.28",
  "log 0.4.20",
- "nix",
+ "nix 0.26.4",
  "uuid",
  "zenoh-core",
  "zenoh-link-commons",
@@ -3880,7 +3890,7 @@ dependencies = [
  "log 0.4.20",
  "tokio",
  "tokio-tungstenite",
- "url 2.4.0",
+ "url 2.4.1",
  "zenoh-core",
  "zenoh-link-commons",
  "zenoh-protocol",

--- a/Cargo.lock
+++ b/Cargo.lock
@@ -1448,9 +1448,9 @@ dependencies = [
 
 [[package]]
 name = "libc"
-version = "0.2.147"
+version = "0.2.148"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "b4668fb0ea861c1df094127ac5f1da3409a82116a4ba74fca2e58ef927159bb3"
+checksum = "9cdc71e17332e86d2e1d38c1f99edcb6288ee11b815fb1a4b049eaa2114d369b"
 
 [[package]]
 name = "libloading"
@@ -2135,7 +2135,7 @@ checksum = "055b4e778e8feb9f93c4e439f71dc2156ef13360b432b799e179a8c4cdf0b1d7"
 dependencies = [
  "bytes",
  "libc",
- "socket2 0.5.3",
+ "socket2 0.5.4",
  "tracing",
  "windows-sys",
 ]
@@ -2287,7 +2287,7 @@ dependencies = [
 [[package]]
 name = "ros_message"
 version = "0.1.1"
-source = "git+https://github.com/ZettaScaleLabs/rosrust.git?branch=feature/fix_bugs#e21ec5b0b6c50e5fe8dc032e12f60142056643bf"
+source = "git+https://github.com/ZettaScaleLabs/rosrust.git?branch=feature/fix_bugs#de0c837033ac1d442403141e0ff2fda5087f119a"
 dependencies = [
  "array-init",
  "hex",
@@ -2303,7 +2303,7 @@ dependencies = [
 [[package]]
 name = "rosrust"
 version = "0.9.11"
-source = "git+https://github.com/ZettaScaleLabs/rosrust.git?branch=feature/fix_bugs#e21ec5b0b6c50e5fe8dc032e12f60142056643bf"
+source = "git+https://github.com/ZettaScaleLabs/rosrust.git?branch=feature/fix_bugs#de0c837033ac1d442403141e0ff2fda5087f119a"
 dependencies = [
  "byteorder",
  "colored",
@@ -2326,7 +2326,7 @@ dependencies = [
 [[package]]
 name = "rosrust_codegen"
 version = "0.9.6"
-source = "git+https://github.com/ZettaScaleLabs/rosrust.git?branch=feature/fix_bugs#e21ec5b0b6c50e5fe8dc032e12f60142056643bf"
+source = "git+https://github.com/ZettaScaleLabs/rosrust.git?branch=feature/fix_bugs#de0c837033ac1d442403141e0ff2fda5087f119a"
 dependencies = [
  "error-chain 0.12.4",
  "hex",
@@ -2465,9 +2465,9 @@ dependencies = [
 
 [[package]]
 name = "rustls-webpki"
-version = "0.101.4"
+version = "0.101.5"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "7d93931baf2d282fff8d3a532bbfd7653f734643161b87e3e01e59a04439bf0d"
+checksum = "45a27e3b59326c16e23d30aeb7a36a24cc0d29e71d68ff611cdfb4a01d013bed"
 dependencies = [
  "ring",
  "untrusted",
@@ -2778,9 +2778,9 @@ dependencies = [
 
 [[package]]
 name = "socket2"
-version = "0.5.3"
+version = "0.5.4"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "2538b18701741680e0322a2302176d3253a35388e2e62f172f64f4f16605f877"
+checksum = "4031e820eb552adee9295814c0ced9e5cf38ddf1e8b7d566d6de8e2538ea989e"
 dependencies = [
  "libc",
  "windows-sys",
@@ -3026,7 +3026,7 @@ dependencies = [
  "mio",
  "num_cpus",
  "pin-project-lite",
- "socket2 0.5.3",
+ "socket2 0.5.4",
  "tokio-macros",
  "windows-sys",
 ]
@@ -3195,9 +3195,9 @@ checksum = "92888ba5573ff080736b3648696b70cafad7d250551175acbaa4e0385b3e1460"
 
 [[package]]
 name = "unicode-ident"
-version = "1.0.11"
+version = "1.0.12"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "301abaae475aa91687eb82514b328ab47a211a533026cb25fc3e519b86adfc3c"
+checksum = "3354b9ac3fae1ff6755cb6db53683adb661634f67557942dea4facebec0fee4b"
 
 [[package]]
 name = "unicode-normalization"
@@ -3584,7 +3584,7 @@ dependencies = [
 [[package]]
 name = "zenoh"
 version = "0.10.0-dev"
-source = "git+https://github.com/eclipse-zenoh/zenoh.git#108dc59c18406cae1160e16aa51fd19f327a2377"
+source = "git+https://github.com/eclipse-zenoh/zenoh.git#a341d7d72acbcdf7e7650f1ff1444a113ddf5314"
 dependencies = [
  "async-global-executor",
  "async-std",
@@ -3607,7 +3607,7 @@ dependencies = [
  "rustc_version",
  "serde",
  "serde_json",
- "socket2 0.5.3",
+ "socket2 0.5.4",
  "stop-token",
  "uhlc",
  "uuid",
@@ -3647,7 +3647,7 @@ dependencies = [
 [[package]]
 name = "zenoh-buffers"
 version = "0.10.0-dev"
-source = "git+https://github.com/eclipse-zenoh/zenoh.git#108dc59c18406cae1160e16aa51fd19f327a2377"
+source = "git+https://github.com/eclipse-zenoh/zenoh.git#a341d7d72acbcdf7e7650f1ff1444a113ddf5314"
 dependencies = [
  "zenoh-collections",
 ]
@@ -3655,7 +3655,7 @@ dependencies = [
 [[package]]
 name = "zenoh-codec"
 version = "0.10.0-dev"
-source = "git+https://github.com/eclipse-zenoh/zenoh.git#108dc59c18406cae1160e16aa51fd19f327a2377"
+source = "git+https://github.com/eclipse-zenoh/zenoh.git#a341d7d72acbcdf7e7650f1ff1444a113ddf5314"
 dependencies = [
  "log 0.4.20",
  "serde",
@@ -3667,12 +3667,12 @@ dependencies = [
 [[package]]
 name = "zenoh-collections"
 version = "0.10.0-dev"
-source = "git+https://github.com/eclipse-zenoh/zenoh.git#108dc59c18406cae1160e16aa51fd19f327a2377"
+source = "git+https://github.com/eclipse-zenoh/zenoh.git#a341d7d72acbcdf7e7650f1ff1444a113ddf5314"
 
 [[package]]
 name = "zenoh-config"
 version = "0.10.0-dev"
-source = "git+https://github.com/eclipse-zenoh/zenoh.git#108dc59c18406cae1160e16aa51fd19f327a2377"
+source = "git+https://github.com/eclipse-zenoh/zenoh.git#a341d7d72acbcdf7e7650f1ff1444a113ddf5314"
 dependencies = [
  "flume",
  "json5",
@@ -3690,7 +3690,7 @@ dependencies = [
 [[package]]
 name = "zenoh-core"
 version = "0.10.0-dev"
-source = "git+https://github.com/eclipse-zenoh/zenoh.git#108dc59c18406cae1160e16aa51fd19f327a2377"
+source = "git+https://github.com/eclipse-zenoh/zenoh.git#a341d7d72acbcdf7e7650f1ff1444a113ddf5314"
 dependencies = [
  "async-std",
  "lazy_static",
@@ -3700,7 +3700,7 @@ dependencies = [
 [[package]]
 name = "zenoh-crypto"
 version = "0.10.0-dev"
-source = "git+https://github.com/eclipse-zenoh/zenoh.git#108dc59c18406cae1160e16aa51fd19f327a2377"
+source = "git+https://github.com/eclipse-zenoh/zenoh.git#a341d7d72acbcdf7e7650f1ff1444a113ddf5314"
 dependencies = [
  "aes",
  "hmac",
@@ -3713,7 +3713,7 @@ dependencies = [
 [[package]]
 name = "zenoh-ext"
 version = "0.10.0-dev"
-source = "git+https://github.com/eclipse-zenoh/zenoh.git#108dc59c18406cae1160e16aa51fd19f327a2377"
+source = "git+https://github.com/eclipse-zenoh/zenoh.git#a341d7d72acbcdf7e7650f1ff1444a113ddf5314"
 dependencies = [
  "async-std",
  "bincode",
@@ -3733,7 +3733,7 @@ dependencies = [
 [[package]]
 name = "zenoh-keyexpr"
 version = "0.10.0-dev"
-source = "git+https://github.com/eclipse-zenoh/zenoh.git#108dc59c18406cae1160e16aa51fd19f327a2377"
+source = "git+https://github.com/eclipse-zenoh/zenoh.git#a341d7d72acbcdf7e7650f1ff1444a113ddf5314"
 dependencies = [
  "hashbrown 0.13.2",
  "keyed-set",
@@ -3747,7 +3747,7 @@ dependencies = [
 [[package]]
 name = "zenoh-link"
 version = "0.10.0-dev"
-source = "git+https://github.com/eclipse-zenoh/zenoh.git#108dc59c18406cae1160e16aa51fd19f327a2377"
+source = "git+https://github.com/eclipse-zenoh/zenoh.git#a341d7d72acbcdf7e7650f1ff1444a113ddf5314"
 dependencies = [
  "async-std",
  "async-trait",
@@ -3766,7 +3766,7 @@ dependencies = [
 [[package]]
 name = "zenoh-link-commons"
 version = "0.10.0-dev"
-source = "git+https://github.com/eclipse-zenoh/zenoh.git#108dc59c18406cae1160e16aa51fd19f327a2377"
+source = "git+https://github.com/eclipse-zenoh/zenoh.git#a341d7d72acbcdf7e7650f1ff1444a113ddf5314"
 dependencies = [
  "async-std",
  "async-trait",
@@ -3782,7 +3782,7 @@ dependencies = [
 [[package]]
 name = "zenoh-link-quic"
 version = "0.10.0-dev"
-source = "git+https://github.com/eclipse-zenoh/zenoh.git#108dc59c18406cae1160e16aa51fd19f327a2377"
+source = "git+https://github.com/eclipse-zenoh/zenoh.git#a341d7d72acbcdf7e7650f1ff1444a113ddf5314"
 dependencies = [
  "async-rustls",
  "async-std",
@@ -3806,7 +3806,7 @@ dependencies = [
 [[package]]
 name = "zenoh-link-tcp"
 version = "0.10.0-dev"
-source = "git+https://github.com/eclipse-zenoh/zenoh.git#108dc59c18406cae1160e16aa51fd19f327a2377"
+source = "git+https://github.com/eclipse-zenoh/zenoh.git#a341d7d72acbcdf7e7650f1ff1444a113ddf5314"
 dependencies = [
  "async-std",
  "async-trait",
@@ -3822,7 +3822,7 @@ dependencies = [
 [[package]]
 name = "zenoh-link-tls"
 version = "0.10.0-dev"
-source = "git+https://github.com/eclipse-zenoh/zenoh.git#108dc59c18406cae1160e16aa51fd19f327a2377"
+source = "git+https://github.com/eclipse-zenoh/zenoh.git#a341d7d72acbcdf7e7650f1ff1444a113ddf5314"
 dependencies = [
  "async-rustls",
  "async-std",
@@ -3845,12 +3845,12 @@ dependencies = [
 [[package]]
 name = "zenoh-link-udp"
 version = "0.10.0-dev"
-source = "git+https://github.com/eclipse-zenoh/zenoh.git#108dc59c18406cae1160e16aa51fd19f327a2377"
+source = "git+https://github.com/eclipse-zenoh/zenoh.git#a341d7d72acbcdf7e7650f1ff1444a113ddf5314"
 dependencies = [
  "async-std",
  "async-trait",
  "log 0.4.20",
- "socket2 0.5.3",
+ "socket2 0.5.4",
  "zenoh-buffers",
  "zenoh-collections",
  "zenoh-core",
@@ -3864,7 +3864,7 @@ dependencies = [
 [[package]]
 name = "zenoh-link-unixsock_stream"
 version = "0.10.0-dev"
-source = "git+https://github.com/eclipse-zenoh/zenoh.git#108dc59c18406cae1160e16aa51fd19f327a2377"
+source = "git+https://github.com/eclipse-zenoh/zenoh.git#a341d7d72acbcdf7e7650f1ff1444a113ddf5314"
 dependencies = [
  "async-std",
  "async-trait",
@@ -3882,7 +3882,7 @@ dependencies = [
 [[package]]
 name = "zenoh-link-ws"
 version = "0.10.0-dev"
-source = "git+https://github.com/eclipse-zenoh/zenoh.git#108dc59c18406cae1160e16aa51fd19f327a2377"
+source = "git+https://github.com/eclipse-zenoh/zenoh.git#a341d7d72acbcdf7e7650f1ff1444a113ddf5314"
 dependencies = [
  "async-std",
  "async-trait",
@@ -3902,7 +3902,7 @@ dependencies = [
 [[package]]
 name = "zenoh-macros"
 version = "0.10.0-dev"
-source = "git+https://github.com/eclipse-zenoh/zenoh.git#108dc59c18406cae1160e16aa51fd19f327a2377"
+source = "git+https://github.com/eclipse-zenoh/zenoh.git#a341d7d72acbcdf7e7650f1ff1444a113ddf5314"
 dependencies = [
  "proc-macro2",
  "quote",
@@ -3947,7 +3947,7 @@ dependencies = [
 [[package]]
 name = "zenoh-plugin-trait"
 version = "0.10.0-dev"
-source = "git+https://github.com/eclipse-zenoh/zenoh.git#108dc59c18406cae1160e16aa51fd19f327a2377"
+source = "git+https://github.com/eclipse-zenoh/zenoh.git#a341d7d72acbcdf7e7650f1ff1444a113ddf5314"
 dependencies = [
  "libloading",
  "log 0.4.20",
@@ -3960,7 +3960,7 @@ dependencies = [
 [[package]]
 name = "zenoh-protocol"
 version = "0.10.0-dev"
-source = "git+https://github.com/eclipse-zenoh/zenoh.git#108dc59c18406cae1160e16aa51fd19f327a2377"
+source = "git+https://github.com/eclipse-zenoh/zenoh.git#a341d7d72acbcdf7e7650f1ff1444a113ddf5314"
 dependencies = [
  "const_format",
  "hex",
@@ -3976,7 +3976,7 @@ dependencies = [
 [[package]]
 name = "zenoh-result"
 version = "0.10.0-dev"
-source = "git+https://github.com/eclipse-zenoh/zenoh.git#108dc59c18406cae1160e16aa51fd19f327a2377"
+source = "git+https://github.com/eclipse-zenoh/zenoh.git#a341d7d72acbcdf7e7650f1ff1444a113ddf5314"
 dependencies = [
  "anyhow",
 ]
@@ -3984,7 +3984,7 @@ dependencies = [
 [[package]]
 name = "zenoh-sync"
 version = "0.10.0-dev"
-source = "git+https://github.com/eclipse-zenoh/zenoh.git#108dc59c18406cae1160e16aa51fd19f327a2377"
+source = "git+https://github.com/eclipse-zenoh/zenoh.git#a341d7d72acbcdf7e7650f1ff1444a113ddf5314"
 dependencies = [
  "async-std",
  "event-listener",
@@ -3999,7 +3999,7 @@ dependencies = [
 [[package]]
 name = "zenoh-transport"
 version = "0.10.0-dev"
-source = "git+https://github.com/eclipse-zenoh/zenoh.git#108dc59c18406cae1160e16aa51fd19f327a2377"
+source = "git+https://github.com/eclipse-zenoh/zenoh.git#a341d7d72acbcdf7e7650f1ff1444a113ddf5314"
 dependencies = [
  "async-executor",
  "async-global-executor",
@@ -4030,7 +4030,7 @@ dependencies = [
 [[package]]
 name = "zenoh-util"
 version = "0.10.0-dev"
-source = "git+https://github.com/eclipse-zenoh/zenoh.git#108dc59c18406cae1160e16aa51fd19f327a2377"
+source = "git+https://github.com/eclipse-zenoh/zenoh.git#a341d7d72acbcdf7e7650f1ff1444a113ddf5314"
 dependencies = [
  "async-std",
  "async-trait",

--- a/zenoh-bridge-ros1/Cargo.toml
+++ b/zenoh-bridge-ros1/Cargo.toml
@@ -34,6 +34,9 @@ zenoh = { workspace = true }
 zenoh-plugin-trait = { workspace = true }
 zenoh-plugin-ros1 = { path = "../zenoh-plugin-ros1/", default-features = false }
 
+[features]
+preserve_topic_metadata = [] # development feature, do not use it
+
 [[bin]]
 name = "zenoh-bridge-ros1"
 path = "src/main.rs"

--- a/zenoh-bridge-ros1/Cargo.toml
+++ b/zenoh-bridge-ros1/Cargo.toml
@@ -34,9 +34,6 @@ zenoh = { workspace = true }
 zenoh-plugin-trait = { workspace = true }
 zenoh-plugin-ros1 = { path = "../zenoh-plugin-ros1/", default-features = false }
 
-[features]
-preserve_topic_metadata = [] # development feature, do not use it
-
 [[bin]]
 name = "zenoh-bridge-ros1"
 path = "src/main.rs"

--- a/zenoh-bridge-ros1/src/main.rs
+++ b/zenoh-bridge-ros1/src/main.rs
@@ -183,7 +183,9 @@ async fn main() {
     let config = parse_args();
 
     // create a zenoh Runtime (to share with plugins)
-    let runtime = zenoh::runtime::Runtime::new(config).await.unwrap();
+    let runtime = zenoh::runtime::Runtime::new(config)
+        .await
+        .expect("Error creating runtime");
 
     // start ros1 plugin
     use zenoh_plugin_trait::Plugin;

--- a/zenoh-bridge-ros1/src/main.rs
+++ b/zenoh-bridge-ros1/src/main.rs
@@ -94,22 +94,28 @@ r#"--ros_hostname=[String]   'A hostname to send to ROS1 Master, the default is 
 r#"--ros_name=[String]   'A bridge node's name for ROS1, the default is "ros1_to_zenoh_bridge"'"#
         ))
         .arg(Arg::from_usage(
+r#"--ros_namespace=[String]   'A bridge's namespace in terms of ROS1, the default is empty'"#
+        ))
+        .arg(Arg::from_usage(
+r#"--with_rosmaster=[bool]   'Start rosmaster with the bridge, the default is "false"'"#
+        ))
+        .arg(Arg::from_usage(
 r#"--subscriber_bridging_mode=[String] \
-'Mode of subscriber's topic bridging. Accepted values:'
+'Global subscriber's topic bridging mode. Accepted values:'
   - "auto"(default) - bridge topics once they are declared locally or discovered remotely
   - "lazy_auto" - bridge topics once they are both declared locally and discovered remotely
   - "disabled" - never bridge topics. This setting will also suppress the topic discovery."#
         ))
         .arg(Arg::from_usage(
 r#"--publisher_bridging_mode=[String] \
-'Mode of publisher's topic bridging. Accepted values:'
+'Global publisher's topic bridging mode. Accepted values:'
   - "auto"(default) - bridge topics once they are declared locally or discovered remotely
   - "lazy_auto" - bridge topics once they are both declared locally and discovered remotely
   - "disabled" - never bridge topics. This setting will also suppress the topic discovery."#
         ))
         .arg(Arg::from_usage(
 r#"--service_bridging_mode=[String] \
-'Mode of service's topic bridging. Accepted values:'
+'Global service's topic bridging mode. Accepted values:'
   - "auto"(default) - bridge topics once they are declared locally or discovered remotely
   - "lazy_auto" - bridge topics once they are both declared locally and discovered remotely
   - "disabled" - never bridge topics. This setting will also suppress the topic discovery."#
@@ -129,7 +135,42 @@ r#"--client_bridging_mode=[String] \
   - globally select auto bridging mode (with caution!) with this option
   - bridge specific topics using 'client_topic_custom_bridging_mode' option (with a little bit less caution!)"#
         ))
-
+        .arg(Arg::from_usage(
+r#"--subscriber_topic_custom_bridging_mode=[JSON]   'A JSON Map describing custom bridging modes for particular topics.
+Custom bridging mode overrides the global one.
+Format: {[topic, mode]}
+where
+- topic: ROS1 topic name
+- mode (auto/lazy_auto/disabled) as described above
+The default is empty'"#
+        ))
+        .arg(Arg::from_usage(
+r#"--publisher_topic_custom_bridging_mode=[JSON]   'A JSON Map describing custom bridging modes for particular topics.
+Custom bridging mode overrides the global one.
+Format: {[topic, mode]}
+where
+- topic: ROS1 topic name
+- mode (auto/lazy_auto/disabled) as described above
+The default is empty'"#
+        ))
+        .arg(Arg::from_usage(
+r#"--service_topic_custom_bridging_mode=[JSON]   'A JSON Map describing custom bridging modes for particular topics.
+Custom bridging mode overrides the global one.
+Format: {[topic, mode]}
+where
+- topic: ROS1 topic name
+- mode (auto/lazy_auto/disabled) as described above
+The default is empty'"#
+        ))
+        .arg(Arg::from_usage(
+r#"--client_topic_custom_bridging_mode=[JSON]   'A JSON Map describing custom bridging modes for particular topics.
+Custom bridging mode overrides the global one.
+Format: {[topic, mode]}
+where
+- topic: ROS1 topic name
+- mode (auto/lazy_auto/disabled) as described above
+The default is empty'"#
+        ))
         .arg(Arg::from_usage(
 r#"--ros_master_polling_interval=[String] \
 'An interval to poll the ROS1 master for status
@@ -137,9 +178,6 @@ Bridge polls ROS1 master to get information on local topics. This option is the 
 Accepted value:'
 A string such as 100ms, 2s, 5m
 The string format is [0-9]+(ns|us|ms|[smhdwy])"#
-        ))
-        .arg(Arg::from_usage(
-r#"--with_rosmaster=[bool]   'An option wether the bridge should run it's own rosmaster process, the default is "false"'"#
         ));
     let args = app.get_matches();
 

--- a/zenoh-plugin-ros1/examples/ros1_pub.rs
+++ b/zenoh-plugin-ros1/examples/ros1_pub.rs
@@ -36,9 +36,11 @@ async fn main() {
 
     // create ROS1 node and publisher
     print!("Creating ROS1 Node...");
-    let ros1_node = rosrust::api::Ros::new(
-        (Environment::ros_name().get() + "_test_source_node").as_str(),
+    let ros1_node = rosrust::api::Ros::new_raw(
         Environment::ros_master_uri().get().as_str(),
+        &rosrust::api::resolve::hostname(),
+        &rosrust::api::resolve::namespace(),
+        (Environment::ros_name().get() + "_test_source_node").as_str(),
     )
     .unwrap();
     println!(" OK!");

--- a/zenoh-plugin-ros1/examples/ros1_service.rs
+++ b/zenoh-plugin-ros1/examples/ros1_service.rs
@@ -38,9 +38,11 @@ async fn main() {
 
     // create ROS1 node and service
     print!("Creating ROS1 Node...");
-    let ros1_node = rosrust::api::Ros::new(
-        (Environment::ros_name().get() + "_test_service_node").as_str(),
+    let ros1_node = rosrust::api::Ros::new_raw(
         Environment::ros_master_uri().get().as_str(),
+        &rosrust::api::resolve::hostname(),
+        &rosrust::api::resolve::namespace(),
+        (Environment::ros_name().get() + "_test_service_node").as_str(),
     )
     .unwrap();
     println!(" OK!");

--- a/zenoh-plugin-ros1/examples/ros1_standalone_pub.rs
+++ b/zenoh-plugin-ros1/examples/ros1_standalone_pub.rs
@@ -31,9 +31,11 @@ async fn main() {
 
     // create ROS1 node and publisher
     print!("Creating ROS1 Node...");
-    let ros1_node = rosrust::api::Ros::new(
-        (Environment::ros_name().get() + "_test_source_node").as_str(),
+    let ros1_node = rosrust::api::Ros::new_raw(
         Environment::ros_master_uri().get().as_str(),
+        &rosrust::api::resolve::hostname(),
+        &rosrust::api::resolve::namespace(),
+        (Environment::ros_name().get() + "_test_source_node").as_str(),
     )
     .expect("Error creating ROS1 Node!");
     println!(" OK!");

--- a/zenoh-plugin-ros1/examples/ros1_standalone_sub.rs
+++ b/zenoh-plugin-ros1/examples/ros1_standalone_sub.rs
@@ -32,9 +32,11 @@ async fn main() {
 
     // create ROS1 node and subscriber
     print!("Creating ROS1 Node...");
-    let ros1_node = rosrust::api::Ros::new(
-        (Environment::ros_name().get() + "_test_subscriber_node").as_str(),
+    let ros1_node = rosrust::api::Ros::new_raw(
         Environment::ros_master_uri().get().as_str(),
+        &rosrust::api::resolve::hostname(),
+        &rosrust::api::resolve::namespace(),
+        (Environment::ros_name().get() + "_test_subscriber_node").as_str(),
     )
     .expect("Error creating ROS1 Node!");
     println!(" OK!");

--- a/zenoh-plugin-ros1/examples/ros1_sub.rs
+++ b/zenoh-plugin-ros1/examples/ros1_sub.rs
@@ -37,9 +37,11 @@ async fn main() {
 
     // create ROS1 node and subscriber
     print!("Creating ROS1 Node...");
-    let ros1_node = rosrust::api::Ros::new(
-        (Environment::ros_name().get() + "_test_subscriber_node").as_str(),
+    let ros1_node = rosrust::api::Ros::new_raw(
         Environment::ros_master_uri().get().as_str(),
+        &rosrust::api::resolve::hostname(),
+        &rosrust::api::resolve::namespace(),
+        (Environment::ros_name().get() + "_test_subscriber_node").as_str(),
     )
     .unwrap();
     println!(" OK!");

--- a/zenoh-plugin-ros1/src/ros_to_zenoh_bridge.rs
+++ b/zenoh-plugin-ros1/src/ros_to_zenoh_bridge.rs
@@ -32,6 +32,8 @@ pub mod aloha_subscription;
 #[cfg(feature = "test")]
 pub mod bridge_type;
 #[cfg(feature = "test")]
+pub mod bridging_mode;
+#[cfg(feature = "test")]
 pub mod discovery;
 #[cfg(feature = "test")]
 pub mod ros1_client;
@@ -50,6 +52,8 @@ mod aloha_declaration;
 mod aloha_subscription;
 #[cfg(not(feature = "test"))]
 mod bridge_type;
+#[cfg(not(feature = "test"))]
+mod bridging_mode;
 #[cfg(not(feature = "test"))]
 mod discovery;
 #[cfg(not(feature = "test"))]

--- a/zenoh-plugin-ros1/src/ros_to_zenoh_bridge.rs
+++ b/zenoh-plugin-ros1/src/ros_to_zenoh_bridge.rs
@@ -40,6 +40,10 @@ pub mod ros1_client;
 #[cfg(feature = "test")]
 pub mod ros1_to_zenoh_bridge_impl;
 #[cfg(feature = "test")]
+pub mod rosclient_test_helpers;
+#[cfg(feature = "test")]
+pub mod service_cache;
+#[cfg(feature = "test")]
 pub mod test_helpers;
 #[cfg(feature = "test")]
 pub mod topic_utilities;
@@ -60,6 +64,8 @@ mod discovery;
 mod ros1_client;
 #[cfg(not(feature = "test"))]
 mod ros1_to_zenoh_bridge_impl;
+#[cfg(not(feature = "test"))]
+mod service_cache;
 #[cfg(not(feature = "test"))]
 mod topic_utilities;
 #[cfg(not(feature = "test"))]

--- a/zenoh-plugin-ros1/src/ros_to_zenoh_bridge/bridge_type.rs
+++ b/zenoh-plugin-ros1/src/ros_to_zenoh_bridge/bridge_type.rs
@@ -12,7 +12,9 @@
 //   ZettaScale Zenoh Team, <zenoh@zettascale.tech>
 //
 
-#[derive(Clone, Copy, PartialEq, Eq)]
+use strum_macros::Display;
+
+#[derive(Clone, Copy, PartialEq, Eq, Display)]
 pub enum BridgeType {
     Publisher,
     Subscriber,

--- a/zenoh-plugin-ros1/src/ros_to_zenoh_bridge/bridges_storage.rs
+++ b/zenoh-plugin-ros1/src/ros_to_zenoh_bridge/bridges_storage.rs
@@ -146,16 +146,16 @@ impl<'a> ComplementaryElementAccessor<'a> {
             }
             Entry::Vacant(val) => {
                 let key = val.key().clone();
-                val.insert(TopicBridge::new(
+                let inserted = val.insert(TopicBridge::new(
                     key,
                     self.access.b_type,
                     self.access.declaration_interface.clone(),
                     self.access.ros1_client.clone(),
                     self.access.zenoh_client.clone(),
-                    Environment::bridging_mode().get(),
-                ))
-                .set_has_complementary_in_zenoh(true)
-                .await;
+                    Environment::remote_bridging_mode().get(),
+                    Environment::local_bridging_mode().get(),
+                ));
+                inserted.set_has_complementary_in_zenoh(true).await;
             }
         }
     }
@@ -219,7 +219,8 @@ impl<'a> ElementAccessor<'a> {
                         self.access.declaration_interface.clone(),
                         self.access.ros1_client.clone(),
                         self.access.zenoh_client.clone(),
-                        Environment::bridging_mode().get(),
+                        Environment::remote_bridging_mode().get(),
+                        Environment::local_bridging_mode().get(),
                     ));
                     inserted.set_present_in_ros1(true).await;
                     smth_changed = true;

--- a/zenoh-plugin-ros1/src/ros_to_zenoh_bridge/bridges_storage.rs
+++ b/zenoh-plugin-ros1/src/ros_to_zenoh_bridge/bridges_storage.rs
@@ -18,9 +18,14 @@ use std::{
 };
 
 use super::{
-    bridge_type::BridgeType, discovery::LocalResources, environment::Environment, ros1_client,
-    ros1_to_zenoh_bridge_impl::BridgeStatus, topic_bridge::TopicBridge,
-    topic_mapping::Ros1TopicMapping, zenoh_client,
+    bridge_type::BridgeType,
+    bridging_mode::{bridging_mode, BridgingMode},
+    discovery::LocalResources,
+    ros1_client,
+    ros1_to_zenoh_bridge_impl::BridgeStatus,
+    topic_bridge::TopicBridge,
+    topic_mapping::Ros1TopicMapping,
+    zenoh_client,
 };
 
 struct Bridges {
@@ -140,22 +145,24 @@ impl<'a> ComplementaryElementAccessor<'a> {
     }
 
     pub async fn complementary_entity_discovered(&mut self, topic: rosrust::api::Topic) {
-        match self.access.container.entry(topic) {
-            Entry::Occupied(mut val) => {
-                val.get_mut().set_has_complementary_in_zenoh(true).await;
-            }
-            Entry::Vacant(val) => {
-                let key = val.key().clone();
-                let inserted = val.insert(TopicBridge::new(
-                    key,
-                    self.access.b_type,
-                    self.access.declaration_interface.clone(),
-                    self.access.ros1_client.clone(),
-                    self.access.zenoh_client.clone(),
-                    Environment::remote_bridging_mode().get(),
-                    Environment::local_bridging_mode().get(),
-                ));
-                inserted.set_has_complementary_in_zenoh(true).await;
+        let b_mode = bridging_mode(self.access.b_type, topic.name.as_str());
+        if b_mode != BridgingMode::Disabled {
+            match self.access.container.entry(topic) {
+                Entry::Occupied(mut val) => {
+                    val.get_mut().set_has_complementary_in_zenoh(true).await;
+                }
+                Entry::Vacant(val) => {
+                    let key = val.key().clone();
+                    let inserted = val.insert(TopicBridge::new(
+                        key,
+                        self.access.b_type,
+                        self.access.declaration_interface.clone(),
+                        self.access.ros1_client.clone(),
+                        self.access.zenoh_client.clone(),
+                        b_mode,
+                    ));
+                    inserted.set_has_complementary_in_zenoh(true).await;
+                }
             }
         }
     }
@@ -208,22 +215,24 @@ impl<'a> ElementAccessor<'a> {
 
         // run through the topics and create corresponding bridges
         for ros_topic in part_of_ros_state.iter() {
-            match self.access.container.entry(ros_topic.clone()) {
-                Entry::Occupied(_val) => {
-                    debug_assert!(false); // that shouldn't happen
-                }
-                Entry::Vacant(val) => {
-                    let inserted = val.insert(TopicBridge::new(
-                        ros_topic.clone(),
-                        self.access.b_type,
-                        self.access.declaration_interface.clone(),
-                        self.access.ros1_client.clone(),
-                        self.access.zenoh_client.clone(),
-                        Environment::remote_bridging_mode().get(),
-                        Environment::local_bridging_mode().get(),
-                    ));
-                    inserted.set_present_in_ros1(true).await;
-                    smth_changed = true;
+            let b_mode = bridging_mode(self.access.b_type, ros_topic.name.as_str());
+            if b_mode != BridgingMode::Disabled {
+                match self.access.container.entry(ros_topic.clone()) {
+                    Entry::Occupied(_val) => {
+                        debug_assert!(false); // that shouldn't happen
+                    }
+                    Entry::Vacant(val) => {
+                        let inserted = val.insert(TopicBridge::new(
+                            ros_topic.clone(),
+                            self.access.b_type,
+                            self.access.declaration_interface.clone(),
+                            self.access.ros1_client.clone(),
+                            self.access.zenoh_client.clone(),
+                            b_mode,
+                        ));
+                        inserted.set_present_in_ros1(true).await;
+                        smth_changed = true;
+                    }
                 }
             }
         }

--- a/zenoh-plugin-ros1/src/ros_to_zenoh_bridge/bridging_mode.rs
+++ b/zenoh-plugin-ros1/src/ros_to_zenoh_bridge/bridging_mode.rs
@@ -1,0 +1,70 @@
+//
+// Copyright (c) 2022 ZettaScale Technology
+//
+// This program and the accompanying materials are made available under the
+// terms of the Eclipse Public License 2.0 which is available at
+// http://www.eclipse.org/legal/epl-2.0, or the Apache License, Version 2.0
+// which is available at https://www.apache.org/licenses/LICENSE-2.0.
+//
+// SPDX-License-Identifier: EPL-2.0 OR Apache-2.0
+//
+// Contributors:
+//   ZettaScale Zenoh Team, <zenoh@zettascale.tech>
+//
+
+use serde::{Deserialize, Serialize};
+use strum_macros::{Display, EnumString};
+
+use super::{bridge_type::BridgeType, environment::Environment};
+
+#[derive(PartialEq, Eq, EnumString, Clone, Display)]
+#[strum(serialize_all = "snake_case")]
+#[derive(Serialize, Deserialize, Debug)]
+pub enum BridgingMode {
+    LazyAuto,
+    Auto,
+    Disabled,
+}
+
+pub(super) fn bridging_mode(entity_type: BridgeType, topic_name: &str) -> BridgingMode {
+    macro_rules! calcmode {
+        ($custom_modes:expr, $default_mode:expr, $topic_name:expr) => {
+            $custom_modes
+                .get()
+                .modes
+                .get($topic_name)
+                .map_or_else(|| $default_mode.get(), |v| v.clone())
+        };
+    }
+
+    match entity_type {
+        BridgeType::Publisher => {
+            calcmode!(
+                Environment::publisher_topic_custom_bridging_mode(),
+                Environment::publisher_bridging_mode(),
+                topic_name
+            )
+        }
+        BridgeType::Subscriber => {
+            calcmode!(
+                Environment::subscriber_topic_custom_bridging_mode(),
+                Environment::subscriber_bridging_mode(),
+                topic_name
+            )
+        }
+        BridgeType::Service => {
+            calcmode!(
+                Environment::service_topic_custom_bridging_mode(),
+                Environment::service_bridging_mode(),
+                topic_name
+            )
+        }
+        BridgeType::Client => {
+            calcmode!(
+                Environment::client_topic_custom_bridging_mode(),
+                Environment::client_bridging_mode(),
+                topic_name
+            )
+        }
+    }
+}

--- a/zenoh-plugin-ros1/src/ros_to_zenoh_bridge/discovery.rs
+++ b/zenoh-plugin-ros1/src/ros_to_zenoh_bridge/discovery.rs
@@ -144,22 +144,13 @@ impl RemoteResources {
         F: Fn(BridgeType, rosrust::api::Topic) -> Box<dyn Future<Output = ()> + Unpin + Send>,
     {
         //let discovery_namespace = discovery.discovery_namespace().ok_or("No discovery_namespace present!")?;
-        let datatype;
-        #[cfg(feature = "preserve_topic_metadata")]
-        {
-            let datatype_bytes = hex::decode(
-                discovery
-                    .data_type()
-                    .ok_or("No data_type present!")?
-                    .as_str(),
-            )?;
-            datatype = std::str::from_utf8(&datatype_bytes)?;
-        }
-
-        #[cfg(not(feature = "preserve_topic_metadata"))]
-        {
-            datatype = "*";
-        }
+        let datatype_bytes = hex::decode(
+            discovery
+                .data_type()
+                .ok_or("No data_type present!")?
+                .as_str(),
+        )?;
+        let datatype = std::str::from_utf8(&datatype_bytes)?;
 
         let resource_class = discovery
             .resource_class()

--- a/zenoh-plugin-ros1/src/ros_to_zenoh_bridge/discovery.rs
+++ b/zenoh-plugin-ros1/src/ros_to_zenoh_bridge/discovery.rs
@@ -62,8 +62,6 @@ impl RemoteResources {
             + Sync
             + 'static,
     {
-        let subscriber: Option<AlohaSubscription>;
-
         // make proper discovery keyexpr
         let mut formatter = discovery_format::formatter();
         let discovery_keyexpr = zenoh::keformat!(
@@ -96,15 +94,13 @@ impl RemoteResources {
         .build()
         .await;
 
-        match subscription {
-            Ok(s) => {
-                subscriber = Some(s);
-            }
+        let subscriber = match subscription {
+            Ok(s) => Some(s),
             Err(e) => {
                 error!("ROS1 Discovery: error creating querying subscriber: {}", e);
-                subscriber = None;
+                None
             }
-        }
+        };
 
         Self {
             _subscriber: subscriber,
@@ -148,13 +144,23 @@ impl RemoteResources {
         F: Fn(BridgeType, rosrust::api::Topic) -> Box<dyn Future<Output = ()> + Unpin + Send>,
     {
         //let discovery_namespace = discovery.discovery_namespace().ok_or("No discovery_namespace present!")?;
-        let datatype_bytes = hex::decode(
-            discovery
-                .data_type()
-                .ok_or("No data_type present!")?
-                .as_str(),
-        )?;
-        let datatype = std::str::from_utf8(&datatype_bytes)?;
+        let datatype;
+        #[cfg(feature = "preserve_topic_metadata")]
+        {
+            let datatype_bytes = hex::decode(
+                discovery
+                    .data_type()
+                    .ok_or("No data_type present!")?
+                    .as_str(),
+            )?;
+            datatype = std::str::from_utf8(&datatype_bytes)?;
+        }
+
+        #[cfg(not(feature = "preserve_topic_metadata"))]
+        {
+            datatype = "*";
+        }
+
         let resource_class = discovery
             .resource_class()
             .ok_or("No resource_class present!")?
@@ -189,7 +195,7 @@ impl LocalResource {
         resource_class: &str,
         topic: &rosrust::api::Topic,
         session: Arc<zenoh::Session>,
-    ) -> LocalResource {
+    ) -> ZResult<LocalResource> {
         // make proper discovery keyexpr
         let mut formatter = discovery_format::formatter();
         let discovery_keyexpr = zenoh::keformat!(
@@ -199,13 +205,12 @@ impl LocalResource {
             data_type = hex::encode(topic.datatype.as_bytes()),
             bridge_namespace = bridge_namespace,
             topic = make_zenoh_key(topic)
-        )
-        .unwrap();
+        )?;
 
         let _declaration =
             AlohaDeclaration::new(session, discovery_keyexpr, Duration::from_secs(1));
 
-        Self { _declaration }
+        Ok(Self { _declaration })
     }
 }
 
@@ -231,7 +236,7 @@ impl LocalResources {
         &self,
         topic: &rosrust::api::Topic,
         b_type: BridgeType,
-    ) -> LocalResource {
+    ) -> ZResult<LocalResource> {
         match b_type {
             BridgeType::Publisher => self.declare_publisher(topic).await,
             BridgeType::Subscriber => self.declare_subscriber(topic).await,
@@ -240,22 +245,22 @@ impl LocalResources {
         }
     }
 
-    pub async fn declare_publisher(&self, topic: &rosrust::api::Topic) -> LocalResource {
+    pub async fn declare_publisher(&self, topic: &rosrust::api::Topic) -> ZResult<LocalResource> {
         self.declare(topic, ROS1_DISCOVERY_INFO_PUBLISHERS_CLASS)
             .await
     }
 
-    pub async fn declare_subscriber(&self, topic: &rosrust::api::Topic) -> LocalResource {
+    pub async fn declare_subscriber(&self, topic: &rosrust::api::Topic) -> ZResult<LocalResource> {
         self.declare(topic, ROS1_DISCOVERY_INFO_SUBSCRIBERS_CLASS)
             .await
     }
 
-    pub async fn declare_service(&self, topic: &rosrust::api::Topic) -> LocalResource {
+    pub async fn declare_service(&self, topic: &rosrust::api::Topic) -> ZResult<LocalResource> {
         self.declare(topic, ROS1_DISCOVERY_INFO_SERVICES_CLASS)
             .await
     }
 
-    pub async fn declare_client(&self, topic: &rosrust::api::Topic) -> LocalResource {
+    pub async fn declare_client(&self, topic: &rosrust::api::Topic) -> ZResult<LocalResource> {
         self.declare(topic, ROS1_DISCOVERY_INFO_CLIENTS_CLASS).await
     }
 
@@ -264,7 +269,7 @@ impl LocalResources {
         &self,
         topic: &rosrust::api::Topic,
         resource_class: &str,
-    ) -> LocalResource {
+    ) -> ZResult<LocalResource> {
         LocalResource::new(
             &self.discovery_namespace,
             &self.bridge_namespace,

--- a/zenoh-plugin-ros1/src/ros_to_zenoh_bridge/environment.rs
+++ b/zenoh-plugin-ros1/src/ros_to_zenoh_bridge/environment.rs
@@ -95,8 +95,12 @@ impl Environment {
         return Entry::new("WITH_ROSMASTER", false);
     }
 
-    pub fn bridging_mode() -> Entry<'static, BridgingMode> {
-        return Entry::new("ROS_BRIDGING_MODE", BridgingMode::Auto);
+    pub fn remote_bridging_mode() -> Entry<'static, BridgingMode> {
+        return Entry::new("ROS_REMOTE_BRIDGING_MODE", BridgingMode::Auto);
+    }
+
+    pub fn local_bridging_mode() -> Entry<'static, BridgingMode> {
+        return Entry::new("ROS_LOCAL_BRIDGING_MODE", BridgingMode::Auto);
     }
 
     pub fn master_polling_interval() -> Entry<'static, DurationString> {
@@ -112,7 +116,8 @@ impl Environment {
             Self::ros_hostname(),
             Self::ros_name(),
             Self::ros_namespace(),
-            Self::bridging_mode().into(),
+            Self::remote_bridging_mode().into(),
+            Self::local_bridging_mode().into(),
             Self::master_polling_interval().into(),
             Self::with_rosmaster().into(),
         ]

--- a/zenoh-plugin-ros1/src/ros_to_zenoh_bridge/environment.rs
+++ b/zenoh-plugin-ros1/src/ros_to_zenoh_bridge/environment.rs
@@ -89,7 +89,11 @@ pub struct CustomBridgingModes {
 
 impl ToString for CustomBridgingModes {
     fn to_string(&self) -> String {
-        todo!()
+        let mut json_map = serde_json::Map::new();
+        for (k, v) in &self.modes {
+            json_map.insert(k.clone(), Value::String(v.to_string()));
+        }
+        serde_json::Value::Object(json_map).to_string()
     }
 }
 

--- a/zenoh-plugin-ros1/src/ros_to_zenoh_bridge/ros1_client.rs
+++ b/zenoh-plugin-ros1/src/ros_to_zenoh_bridge/ros1_client.rs
@@ -14,6 +14,7 @@
 
 use log::debug;
 use rosrust;
+use zenoh_core::{zerror, zresult::ZResult};
 
 pub struct Ros1Client {
     ros: rosrust::api::Ros,
@@ -21,10 +22,16 @@ pub struct Ros1Client {
 
 impl Ros1Client {
     // PUBLIC
-    pub fn new(name: &str, master_uri: &str) -> Ros1Client {
-        Ros1Client {
-            ros: rosrust::api::Ros::new(name, master_uri).unwrap(),
-        }
+    pub fn new(name: &str, master_uri: &str) -> ZResult<Ros1Client> {
+        Ok(Ros1Client {
+            ros: rosrust::api::Ros::new_raw(
+                master_uri,
+                &rosrust::api::resolve::hostname(),
+                &rosrust::api::resolve::namespace(),
+                name,
+            )
+            .map_err(|e| zerror!("{e}"))?,
+        })
     }
 
     pub fn subscribe<T, F>(

--- a/zenoh-plugin-ros1/src/ros_to_zenoh_bridge/ros1_master_ctrl.rs
+++ b/zenoh-plugin-ros1/src/ros_to_zenoh_bridge/ros1_master_ctrl.rs
@@ -19,7 +19,7 @@ use async_std::{
 use atoi::atoi;
 use log::error;
 use zenoh::plugins::ZResult;
-use zenoh_core::{bail, zerror};
+use zenoh_core::{bail, zasynclock, zerror};
 
 use crate::ros_to_zenoh_bridge::environment::Environment;
 
@@ -37,7 +37,7 @@ impl Ros1MasterCtrl {
         let port =
             atoi::<u16>(port_str.as_bytes()).ok_or("Unable to parse port from ros_master_uri!")?;
 
-        let mut locked = ROSMASTER.lock().await;
+        let mut locked = zasynclock!(ROSMASTER);
         assert!(locked.is_none());
         let child = Command::new("rosmaster")
             .arg(format!("-p {}", port).as_str())
@@ -50,7 +50,7 @@ impl Ros1MasterCtrl {
     }
 
     pub async fn without_ros1_master() {
-        let mut locked = ROSMASTER.lock().await;
+        let mut locked = zasynclock!(ROSMASTER);
         assert!(locked.is_some());
         match locked.take() {
             Some(mut child) => match child.kill() {

--- a/zenoh-plugin-ros1/src/ros_to_zenoh_bridge/rosclient_test_helpers.rs
+++ b/zenoh-plugin-ros1/src/ros_to_zenoh_bridge/rosclient_test_helpers.rs
@@ -1,0 +1,40 @@
+//
+// Copyright (c) 2022 ZettaScale Technology
+//
+// This program and the accompanying materials are made available under the
+// terms of the Eclipse Public License 2.0 which is available at
+// http://www.eclipse.org/legal/epl-2.0, or the Apache License, Version 2.0
+// which is available at https://www.apache.org/licenses/LICENSE-2.0.
+//
+// SPDX-License-Identifier: EPL-2.0 OR Apache-2.0
+//
+// Contributors:
+//   ZettaScale Zenoh Team, <zenoh@zettascale.tech>
+//
+
+use std::time::Duration;
+
+use rosrust::{Publisher, RawMessage, Subscriber};
+
+use super::{ros1_client::Ros1Client, test_helpers::wait};
+
+pub fn wait_for_rosclient_to_connect(rosclient: &Ros1Client) -> bool {
+    async_std::task::block_on(wait(
+        || rosclient.topic_types().is_ok(),
+        Duration::from_secs(10),
+    ))
+}
+
+pub fn wait_for_publishers(subscriber: &Subscriber, count: usize) -> bool {
+    async_std::task::block_on(wait(
+        || subscriber.publisher_count() == count,
+        Duration::from_secs(10),
+    ))
+}
+
+pub fn wait_for_subscribers(publisher: &Publisher<RawMessage>, count: usize) -> bool {
+    async_std::task::block_on(wait(
+        || publisher.subscriber_count() == count,
+        Duration::from_secs(10),
+    ))
+}

--- a/zenoh-plugin-ros1/src/ros_to_zenoh_bridge/service_cache.rs
+++ b/zenoh-plugin-ros1/src/ros_to_zenoh_bridge/service_cache.rs
@@ -1,0 +1,90 @@
+//
+// Copyright (c) 2022 ZettaScale Technology
+//
+// This program and the accompanying materials are made available under the
+// terms of the Eclipse Public License 2.0 which is available at
+// http://www.eclipse.org/legal/epl-2.0, or the Apache License, Version 2.0
+// which is available at https://www.apache.org/licenses/LICENSE-2.0.
+//
+// SPDX-License-Identifier: EPL-2.0 OR Apache-2.0
+//
+// Contributors:
+//   ZettaScale Zenoh Team, <zenoh@zettascale.tech>
+//
+
+use rosrust::api::Topic;
+use std::{
+    collections::{hash_map::Entry, HashMap},
+    time::Duration,
+};
+use zenoh_core::{zerror, zresult::ZResult};
+
+use super::ros1_client::Ros1Client;
+
+type ServiceName = String;
+type NodeName = String;
+type DataType = String;
+
+/**
+ * Ros1ServiceCache - caching resolver for service's data type
+ */
+pub struct Ros1ServiceCache {
+    aux_node: Ros1Client,
+    cache: HashMap<ServiceName, HashMap<NodeName, DataType>>,
+}
+
+impl Ros1ServiceCache {
+    pub fn new(aux_ros_node_name: &str, ros_master_uri: &str) -> ZResult<Ros1ServiceCache> {
+        let aux_node = Ros1Client::new(aux_ros_node_name, ros_master_uri)?;
+        Ok(Ros1ServiceCache {
+            aux_node,
+            cache: HashMap::default(),
+        })
+    }
+
+    pub fn resolve_datatype(&mut self, service: ServiceName, node: NodeName) -> ZResult<DataType> {
+        match self.cache.entry(service.clone()) {
+            Entry::Occupied(mut occupied) => {
+                match occupied.get_mut().entry(node) {
+                    Entry::Occupied(occupied) => {
+                        // return already resolved datatype
+                        Ok(occupied.get().clone())
+                    }
+                    Entry::Vacant(vacant) => {
+                        // actively resolve datatype through network
+                        let datatype = Self::resolve(&self.aux_node, service)?;
+
+                        // save in cache and return datatype
+                        Ok(vacant.insert(datatype).clone())
+                    }
+                }
+            }
+            Entry::Vacant(vacant) => {
+                // actively resolve datatype through network
+                let datatype = Self::resolve(&self.aux_node, service)?;
+
+                // save in cache and return datatype
+                let mut node_map = HashMap::new();
+                node_map.insert(node, datatype.clone());
+                vacant.insert(node_map);
+                Ok(datatype)
+            }
+        }
+    }
+
+    fn resolve(aux_node: &Ros1Client, service: ServiceName) -> ZResult<DataType> {
+        let resolving_client = aux_node
+            .client(&Topic {
+                name: service,
+                datatype: "*".to_string(),
+            })
+            .map_err(|e| zerror!("{e}"))?;
+        let mut probe = resolving_client
+            .probe(Duration::from_secs(1))
+            .map_err(|e| zerror!("{e}"))?;
+        let datatype = probe
+            .remove("type")
+            .ok_or("no data_type field in service's responce!")?;
+        Ok(datatype)
+    }
+}

--- a/zenoh-plugin-ros1/src/ros_to_zenoh_bridge/test_helpers.rs
+++ b/zenoh-plugin-ros1/src/ros_to_zenoh_bridge/test_helpers.rs
@@ -390,7 +390,7 @@ impl BridgeChecker {
     }
 
     pub fn make_topic(name: &str) -> rosrust::api::Topic {
-        topic_utilities::make_topic("some/very.complicated/datatype//", name.try_into().unwrap())
+        topic_utilities::make_topic("some/testdatatype", name.try_into().unwrap())
     }
 
     pub fn make_zenoh_key(topic: &rosrust::api::Topic) -> &str {

--- a/zenoh-plugin-ros1/src/ros_to_zenoh_bridge/test_helpers.rs
+++ b/zenoh-plugin-ros1/src/ros_to_zenoh_bridge/test_helpers.rs
@@ -135,7 +135,8 @@ impl RunningBridge {
                 *my_status = status;
             },
         )
-        .await;
+        .await
+        .unwrap();
     }
 
     pub async fn assert_ros_error(&self) {
@@ -177,8 +178,9 @@ impl RunningBridge {
     ) -> bool {
         wait(
             move || {
-                let val = self.bridge_status.lock().unwrap();
-                *val == (status)()
+                let expected = (status)();
+                let real = self.bridge_status.lock().unwrap();
+                *real == expected
             },
             timeout,
         )
@@ -255,7 +257,7 @@ impl BridgeChecker {
     pub fn new(config: zenoh::config::Config, ros_master_uri: &str) -> BridgeChecker {
         let session = zenoh::open(config).res_sync().unwrap().into_arc();
         BridgeChecker {
-            ros_client: ros1_client::Ros1Client::new("test_ros_node", ros_master_uri),
+            ros_client: ros1_client::Ros1Client::new("test_ros_node", ros_master_uri).unwrap(),
             zenoh_client: zenoh_client::ZenohClient::new(session.clone()),
             local_resources: LocalResources::new("*".to_string(), "*".to_string(), session),
             expected_bridge_status: Arc::new(RwLock::new(BridgeStatus::default())),

--- a/zenoh-plugin-ros1/src/ros_to_zenoh_bridge/test_helpers.rs
+++ b/zenoh-plugin-ros1/src/ros_to_zenoh_bridge/test_helpers.rs
@@ -20,6 +20,7 @@ use std::sync::{Arc, Mutex, RwLock};
 use std::{net::SocketAddr, str::FromStr, sync::atomic::AtomicU16};
 use zenoh::config::ModeDependentValue;
 use zenoh::sample::Sample;
+use zenoh_core::zlock;
 use zenoh_core::{AsyncResolve, SyncResolve};
 
 use super::discovery::LocalResources;
@@ -127,11 +128,11 @@ impl RunningBridge {
             session,
             flag,
             move |v| {
-                let mut val = ros_status.lock().unwrap();
+                let mut val = zlock!(ros_status);
                 *val = v;
             },
             move |status| {
-                let mut my_status = bridge_status.lock().unwrap();
+                let mut my_status = zlock!(bridge_status);
                 *my_status = status;
             },
         )

--- a/zenoh-plugin-ros1/src/ros_to_zenoh_bridge/topic_bridge.rs
+++ b/zenoh-plugin-ros1/src/ros_to_zenoh_bridge/topic_bridge.rs
@@ -19,7 +19,7 @@ use super::{
     ros1_client, zenoh_client,
 };
 use log::error;
-use std::sync::Arc;
+use std::{fmt::Display, sync::Arc};
 use strum_macros::{Display, EnumString};
 
 #[derive(PartialEq, Eq, EnumString, Clone, Display)]
@@ -35,7 +35,8 @@ pub struct TopicBridge {
     ros1_client: Arc<ros1_client::Ros1Client>,
     zenoh_client: Arc<zenoh_client::ZenohClient>,
 
-    briging_mode: BridgingMode,
+    remote_bridging_mode: BridgingMode,
+    local_bridging_mode: BridgingMode,
     required_on_ros1_side: bool,
     required_on_zenoh_side: bool,
 
@@ -45,6 +46,12 @@ pub struct TopicBridge {
     bridge: Option<AbstractBridge>,
 }
 
+impl Display for TopicBridge {
+    fn fmt(&self, f: &mut std::fmt::Formatter<'_>) -> std::fmt::Result {
+        write!(f, "{}:{:?}", self.b_type, self.topic)
+    }
+}
+
 impl TopicBridge {
     pub fn new(
         topic: rosrust::api::Topic,
@@ -52,14 +59,16 @@ impl TopicBridge {
         declaration_interface: Arc<LocalResources>,
         ros1_client: Arc<ros1_client::Ros1Client>,
         zenoh_client: Arc<zenoh_client::ZenohClient>,
-        briging_mode: BridgingMode,
+        remote_bridging_mode: BridgingMode,
+        local_bridging_mode: BridgingMode,
     ) -> Self {
         Self {
             topic,
             b_type,
             ros1_client,
             zenoh_client,
-            briging_mode,
+            remote_bridging_mode,
+            local_bridging_mode,
             required_on_ros1_side: false,
             required_on_zenoh_side: false,
             declaration_interface,
@@ -91,10 +100,7 @@ impl TopicBridge {
     }
 
     pub fn is_actual(&self) -> bool {
-        match self.briging_mode {
-            BridgingMode::Lazy => self.required_on_ros1_side || self.required_on_zenoh_side,
-            BridgingMode::Auto => self.required_on_ros1_side,
-        }
+        self.required_on_ros1_side || self.required_on_zenoh_side
     }
 
     //PRIVATE:
@@ -106,11 +112,14 @@ impl TopicBridge {
     async fn recalc_declaration(&mut self) {
         match (self.required_on_ros1_side, &self.declaration) {
             (true, None) => {
-                self.declaration = Some(
-                    self.declaration_interface
-                        .declare_with_type(&self.topic, self.b_type)
-                        .await,
-                );
+                match self
+                    .declaration_interface
+                    .declare_with_type(&self.topic, self.b_type)
+                    .await
+                {
+                    Ok(decl) => self.declaration = Some(decl),
+                    Err(e) => error!("{self}: error declaring discovery: {e}"),
+                }
             }
             (false, Some(_)) => {
                 self.declaration = None;
@@ -121,13 +130,19 @@ impl TopicBridge {
 
     async fn recalc_bridging(&mut self) {
         let is_discovered_client = self.b_type == BridgeType::Client && self.required_on_zenoh_side;
-        let is_required = self.required_on_ros1_side
-            && (self.briging_mode == BridgingMode::Auto || self.required_on_zenoh_side);
 
-        if is_required || is_discovered_client {
-            self.create_bridge().await;
-        } else {
-            self.bridge = None;
+        let is_required = is_discovered_client
+            || match (self.required_on_zenoh_side, self.required_on_ros1_side) {
+                (true, true) => true,
+                (true, false) => self.remote_bridging_mode == BridgingMode::Auto,
+                (false, true) => self.local_bridging_mode == BridgingMode::Auto,
+                (false, false) => false,
+            };
+
+        match (is_required, self.bridge.as_ref()) {
+            (true, Some(_)) => {}
+            (true, None) => self.create_bridge().await,
+            (false, _) => self.bridge = None,
         }
     }
 
@@ -145,7 +160,7 @@ impl TopicBridge {
             }
             Err(e) => {
                 self.bridge = None;
-                error!("Error creating bridge: {}", e);
+                error!("{self}: error creating bridge: {e}");
             }
         }
     }

--- a/zenoh-plugin-ros1/src/ros_to_zenoh_bridge/topic_mapping.rs
+++ b/zenoh-plugin-ros1/src/ros_to_zenoh_bridge/topic_mapping.rs
@@ -54,6 +54,7 @@ impl Ros1TopicMapping {
         result
     }
 
+    #[cfg(feature = "preserve_topic_metadata")]
     fn fill(
         dst: &mut HashSet<rosrust::api::Topic>,
         data: &[rosrust::api::TopicData],
@@ -73,6 +74,20 @@ impl Ros1TopicMapping {
                     dst.insert(val.clone());
                 }
             }
+        }
+    }
+
+    #[cfg(not(feature = "preserve_topic_metadata"))]
+    fn fill(
+        dst: &mut HashSet<rosrust::api::Topic>,
+        data: &[rosrust::api::TopicData],
+        _topics: &[rosrust::api::Topic],
+    ) {
+        for item in data.iter() {
+            dst.insert(rosrust::api::Topic {
+                name: item.name.clone(),
+                datatype: "*".to_string(),
+            });
         }
     }
 }

--- a/zenoh-plugin-ros1/tests/bridge_to_bridge.rs
+++ b/zenoh-plugin-ros1/tests/bridge_to_bridge.rs
@@ -18,9 +18,13 @@ use rosrust::{Client, Publisher, RawMessage, Service, Subscriber};
 use std::sync::atomic::Ordering::*;
 use strum_macros::Display;
 use zenoh::prelude::KeyExpr;
-use zenoh_plugin_ros1::ros_to_zenoh_bridge::test_helpers::{
-    BridgeChecker, IsolatedConfig, IsolatedROSMaster, RAIICounter, ROSEnvironment, RunningBridge,
-    TestParams,
+use zenoh_plugin_ros1::ros_to_zenoh_bridge::{
+    bridging_mode::BridgingMode,
+    environment::Environment,
+    test_helpers::{
+        BridgeChecker, IsolatedConfig, IsolatedROSMaster, RAIICounter, ROSEnvironment,
+        RunningBridge, TestParams,
+    },
 };
 
 struct ROSWithChecker {
@@ -233,6 +237,9 @@ async fn async_bridge_2_bridge(instances: u32, mode: std::collections::HashSet<M
             entities.push(Entity::Pub(dst_checker.make_ros_publisher(topic.as_str())));
         }
         if mode.contains(&Mode::Ros1Service) {
+            // allow automatical client bridging because it is disabled by default
+            Environment::client_bridging_mode().set(BridgingMode::Auto);
+
             let topic = make_keyexpr(i, Mode::Ros1Service);
             entities.push(Entity::Service(
                 src_checker.make_ros_service(topic.as_str(), Ok),
@@ -240,6 +247,9 @@ async fn async_bridge_2_bridge(instances: u32, mode: std::collections::HashSet<M
             entities.push(Entity::Client(dst_checker.make_ros_client(topic.as_str())));
         }
         if mode.contains(&Mode::Ros1Client) {
+            // allow automatical client bridging because it is disabled by default
+            Environment::client_bridging_mode().set(BridgingMode::Auto);
+
             let topic = make_keyexpr(i, Mode::Ros1Client);
             entities.push(Entity::Client(src_checker.make_ros_client(topic.as_str())));
             entities.push(Entity::Service(

--- a/zenoh-plugin-ros1/tests/discovery_test.rs
+++ b/zenoh-plugin-ros1/tests/discovery_test.rs
@@ -19,7 +19,6 @@ use std::{
 
 use async_std::prelude::FutureExt;
 use multiset::HashMultiSet;
-use rosrust::api::Topic;
 use zenoh::{prelude::keyexpr, OpenBuilder, Session};
 use zenoh_core::{AsyncResolve, SyncResolve};
 use zenoh_plugin_ros1::ros_to_zenoh_bridge::{
@@ -150,31 +149,8 @@ impl DiscoveryCollector {
         container: &Arc<Mutex<HashMultiSet<rosrust::api::Topic>>>,
         expected: HashMultiSet<rosrust::api::Topic>,
     ) {
-        #[cfg(feature = "preserve_topic_metadata")]
         while expected != *container.lock().unwrap() {
             async_std::task::sleep(core::time::Duration::from_millis(10)).await;
-        }
-        #[cfg(not(feature = "preserve_topic_metadata"))]
-        {
-            let comparator = || {
-                let locked = container.lock().unwrap();
-                if locked.len() != expected.len() {
-                    return false;
-                }
-                for e in expected.iter() {
-                    if !locked.contains(&Topic {
-                        name: e.name.clone(),
-                        datatype: "*".to_string(),
-                    }) {
-                        return false;
-                    }
-                }
-
-                true
-            };
-            while !comparator() {
-                async_std::task::sleep(core::time::Duration::from_millis(10)).await;
-            }
         }
     }
 }

--- a/zenoh-plugin-ros1/tests/ping_pong_test.rs
+++ b/zenoh-plugin-ros1/tests/ping_pong_test.rs
@@ -24,8 +24,10 @@ use std::{
     },
 };
 
-use zenoh_plugin_ros1::ros_to_zenoh_bridge::test_helpers::{
-    BridgeChecker, ROSEnvironment, RunningBridge, TestParams,
+use zenoh_plugin_ros1::ros_to_zenoh_bridge::{
+    bridging_mode::BridgingMode,
+    environment::Environment,
+    test_helpers::{BridgeChecker, ROSEnvironment, RunningBridge, TestParams},
 };
 use zenoh_plugin_ros1::ros_to_zenoh_bridge::{
     discovery::LocalResource,
@@ -669,6 +671,9 @@ async fn ping_pong_duplex_parallel_many_(
             );
         }
         if mode.contains(&Mode::Ros1Client) {
+            // allow automatical client bridging because it is disabled by default
+            Environment::client_bridging_mode().set(BridgingMode::Auto);
+
             ping_pongs.push(
                 PingPong::new_ros1_to_zenoh_client(
                     make_keyexpr(i, Mode::Ros1Client).as_str(),

--- a/zenoh-plugin-ros1/tests/ping_pong_test.rs
+++ b/zenoh-plugin-ros1/tests/ping_pong_test.rs
@@ -384,7 +384,8 @@ impl PingPong {
         let discovery_resource = backend
             .local_resources
             .declare_client(&BridgeChecker::make_topic(key))
-            .await;
+            .await
+            .unwrap();
         let zenoh_query = ZenohQuery::new(backend, key.to_string(), cycles.clone());
 
         PingPong {
@@ -406,7 +407,8 @@ impl PingPong {
         let discovery_resource = backend
             .local_resources
             .declare_service(&BridgeChecker::make_topic(key))
-            .await;
+            .await
+            .unwrap();
         let zenoh_queryable = backend
             .make_zenoh_queryable(key, |q| {
                 async_std::task::spawn(async move {
@@ -437,7 +439,8 @@ impl PingPong {
         let discovery_resource = backend
             .local_resources
             .declare_subscriber(&BridgeChecker::make_topic(key))
-            .await;
+            .await
+            .unwrap();
 
         let c = cycles.clone();
         let rpub = ros1_pub.clone();
@@ -471,7 +474,8 @@ impl PingPong {
         let discovery_resource = backend
             .local_resources
             .declare_publisher(&BridgeChecker::make_topic(key))
-            .await;
+            .await
+            .unwrap();
 
         let c = cycles.clone();
         let zpub = zenoh_pub.clone();

--- a/zenoh-plugin-ros1/tests/ros_test.rs
+++ b/zenoh-plugin-ros1/tests/ros_test.rs
@@ -1,0 +1,267 @@
+//
+// Copyright (c) 2022 ZettaScale Technology
+//
+// This program and the accompanying materials are made available under the
+// terms of the Eclipse Public License 2.0 which is available at
+// http://www.eclipse.org/legal/epl-2.0, or the Apache License, Version 2.0
+// which is available at https://www.apache.org/licenses/LICENSE-2.0.
+//
+// SPDX-License-Identifier: EPL-2.0 OR Apache-2.0
+//
+// Contributors:
+//   ZettaScale Zenoh Team, <zenoh@zettascale.tech>
+//
+
+use std::time::Duration;
+
+use rosrust::{Publisher, RawMessage, Subscriber};
+use zenoh_plugin_ros1::ros_to_zenoh_bridge::{
+    ros1_client::Ros1Client,
+    test_helpers::{wait, BridgeChecker, IsolatedROSMaster, ROSEnvironment},
+};
+
+fn wait_for_rosclient_to_connect(rosclient: &Ros1Client) -> bool {
+    async_std::task::block_on(wait(
+        || rosclient.topic_types().is_ok(),
+        Duration::from_secs(10),
+    ))
+}
+
+fn wait_for_publishers(subscriber: &Subscriber, count: usize) -> bool {
+    async_std::task::block_on(wait(
+        || subscriber.publisher_count() == count,
+        Duration::from_secs(10),
+    ))
+}
+
+fn wait_for_subscribers(publisher: &Publisher<RawMessage>, count: usize) -> bool {
+    async_std::task::block_on(wait(
+        || publisher.subscriber_count() == count,
+        Duration::from_secs(10),
+    ))
+}
+
+#[test]
+fn check_rosclient_connectivity_ros_then_client() {
+    // init and start isolated ros
+    let roscfg = IsolatedROSMaster::default();
+    let _ros_env = ROSEnvironment::new(roscfg.port.port).with_master();
+
+    // start rosclient
+    let rosclient = Ros1Client::new("test_client", &roscfg.master_uri()).unwrap();
+    assert!(wait_for_rosclient_to_connect(&rosclient));
+}
+
+#[test]
+fn check_rosclient_connectivity_client_then_ros() {
+    // reserve isolated ros config
+    let roscfg = IsolatedROSMaster::default();
+
+    // start rosclient
+    let rosclient =
+        Ros1Client::new("test_client", &roscfg.master_uri()).expect("error creating Ros1Client!");
+
+    // start rosmaster
+    let _ros_env = ROSEnvironment::new(roscfg.port.port).with_master();
+
+    // check that the client is connected
+    assert!(wait_for_rosclient_to_connect(&rosclient));
+}
+
+#[test]
+fn check_rosclient_pub_sub_connection_pub_then_sub() {
+    // init and start isolated ros
+    let roscfg = IsolatedROSMaster::default();
+    let _ros_env = ROSEnvironment::new(roscfg.port.port).with_master();
+
+    // start rosclients
+    let rosclient1 =
+        Ros1Client::new("test_client1", &roscfg.master_uri()).expect("error creating Ros1Client1!");
+    let rosclient2 =
+        Ros1Client::new("test_client2", &roscfg.master_uri()).expect("error creating Ros1Client2!");
+    assert!(wait_for_rosclient_to_connect(&rosclient1));
+    assert!(wait_for_rosclient_to_connect(&rosclient2));
+
+    // create shared topic
+    let shared_topic = BridgeChecker::make_topic("check_rosclient_pub_sub_connection");
+
+    // create publisher and subscriber
+    let publisher = rosclient1
+        .publish(&shared_topic)
+        .expect("error creating publisher!");
+    let subscriber = rosclient2
+        .subscribe(&shared_topic, |_: RawMessage| {})
+        .expect("error creating subscriber!");
+
+    // check that they are connected
+    assert!(wait_for_publishers(&subscriber, 1));
+    assert!(wait_for_subscribers(&publisher, 1));
+
+    // wait and check that they are still connected
+    std::thread::sleep(Duration::from_secs(5));
+    assert!(subscriber.publisher_count() == 1);
+    assert!(publisher.subscriber_count() == 1);
+}
+
+#[test]
+fn check_rosclient_pub_sub_connection_sub_then_pub() {
+    // init and start isolated ros
+    let roscfg = IsolatedROSMaster::default();
+    let _ros_env = ROSEnvironment::new(roscfg.port.port).with_master();
+
+    // start rosclients
+    let rosclient1 =
+        Ros1Client::new("test_client1", &roscfg.master_uri()).expect("error creating Ros1Client1!");
+    let rosclient2 =
+        Ros1Client::new("test_client2", &roscfg.master_uri()).expect("error creating Ros1Client2!");
+    assert!(wait_for_rosclient_to_connect(&rosclient1));
+    assert!(wait_for_rosclient_to_connect(&rosclient2));
+
+    // create shared topic
+    let shared_topic = BridgeChecker::make_topic("check_rosclient_pub_sub_connection");
+
+    // create subscriber and publisher
+    let subscriber = rosclient2
+        .subscribe(&shared_topic, |_: RawMessage| {})
+        .expect("error creating subscriber!");
+    let publisher = rosclient1
+        .publish(&shared_topic)
+        .expect("error creating publisher!");
+
+    // check that they are connected
+    assert!(wait_for_publishers(&subscriber, 1));
+    assert!(wait_for_subscribers(&publisher, 1));
+
+    // wait and check that they are still connected
+    std::thread::sleep(Duration::from_secs(5));
+    assert!(subscriber.publisher_count() == 1);
+    assert!(publisher.subscriber_count() == 1);
+}
+
+#[test]
+fn check_rosclient_pub_sub_isolation_pub_then_sub() {
+    // init and start isolated ros
+    let roscfg = IsolatedROSMaster::default();
+    let _ros_env = ROSEnvironment::new(roscfg.port.port).with_master();
+
+    // start rosclient
+    let rosclient =
+        Ros1Client::new("test_client", &roscfg.master_uri()).expect("error creating Ros1Client!");
+    assert!(wait_for_rosclient_to_connect(&rosclient));
+
+    // create shared topic
+    let shared_topic = BridgeChecker::make_topic("check_rosclient_pub_sub_isolation");
+
+    // create publisher and subscriber
+    let publisher = rosclient
+        .publish(&shared_topic)
+        .expect("error creating publisher!");
+    let subscriber = rosclient
+        .subscribe(&shared_topic, |_: RawMessage| {})
+        .expect("error creating subscriber!");
+
+    // check that they are isolated
+    assert!(subscriber.publisher_count() == 0);
+    assert!(publisher.subscriber_count() == 0);
+
+    // wait and check that they are still isolated
+    std::thread::sleep(Duration::from_secs(5));
+    assert!(subscriber.publisher_count() == 0);
+    assert!(publisher.subscriber_count() == 0);
+}
+
+#[test]
+fn check_rosclient_pub_sub_isolation_sub_then_pub() {
+    // init and start isolated ros
+    let roscfg = IsolatedROSMaster::default();
+    let _ros_env = ROSEnvironment::new(roscfg.port.port).with_master();
+
+    // start rosclient
+    let rosclient =
+        Ros1Client::new("test_client", &roscfg.master_uri()).expect("error creating Ros1Client!");
+    assert!(wait_for_rosclient_to_connect(&rosclient));
+
+    // create shared topic
+    let shared_topic = BridgeChecker::make_topic("check_rosclient_pub_sub_isolation");
+
+    // create publisher and subscriber
+    let subscriber = rosclient
+        .subscribe(&shared_topic, |_: RawMessage| {})
+        .expect("error creating subscriber!");
+    let publisher = rosclient
+        .publish(&shared_topic)
+        .expect("error creating publisher!");
+
+    // check that they are isolated
+    assert!(subscriber.publisher_count() == 0);
+    assert!(publisher.subscriber_count() == 0);
+
+    // wait and check that they are still isolated
+    std::thread::sleep(Duration::from_secs(5));
+    assert!(subscriber.publisher_count() == 0);
+    assert!(publisher.subscriber_count() == 0);
+}
+
+#[test]
+fn prove_rosclient_service_non_isolation_service_then_client() {
+    // init and start isolated ros
+    let roscfg = IsolatedROSMaster::default();
+    let _ros_env = ROSEnvironment::new(roscfg.port.port).with_master();
+
+    // start rosclient
+    let rosclient =
+        Ros1Client::new("test_client", &roscfg.master_uri()).expect("error creating Ros1Client!");
+    assert!(wait_for_rosclient_to_connect(&rosclient));
+
+    // create shared topic
+    let shared_topic = BridgeChecker::make_topic("prove_rosclient_service_non_isolation");
+
+    // create service and client
+    let _service = rosclient
+        .service::<rosrust::RawMessage, _>(&shared_topic, Ok)
+        .expect("error creating service!");
+    let client = rosclient
+        .client(&shared_topic)
+        .expect("error creating client!");
+
+    // check that they are isolated
+    assert!(client.probe(Duration::from_secs(1)).is_ok());
+    assert!(client.req(&RawMessage::default()).is_ok());
+
+    // wait and check that they are still isolated
+    std::thread::sleep(Duration::from_secs(5));
+    assert!(client.probe(Duration::from_secs(1)).is_ok());
+    assert!(client.req(&RawMessage::default()).is_ok());
+}
+
+#[test]
+fn prove_rosclient_service_non_isolation_client_then_service() {
+    // init and start isolated ros
+    let roscfg = IsolatedROSMaster::default();
+    let _ros_env = ROSEnvironment::new(roscfg.port.port).with_master();
+
+    // start rosclient
+    let rosclient =
+        Ros1Client::new("test_client", &roscfg.master_uri()).expect("error creating Ros1Client!");
+    assert!(wait_for_rosclient_to_connect(&rosclient));
+
+    // create shared topic
+    let shared_topic = BridgeChecker::make_topic("prove_rosclient_service_non_isolation");
+
+    // create client and service
+    let client = rosclient
+        .client(&shared_topic)
+        .expect("error creating client!");
+    let _service = rosclient
+        .service::<rosrust::RawMessage, _>(&shared_topic, Ok)
+        .expect("error creating service!");
+
+    // check that they are isolated
+    assert!(client.probe(Duration::from_secs(1)).is_ok());
+    assert!(client.req(&RawMessage::default()).is_ok());
+
+    // wait and check that they are still isolated
+    std::thread::sleep(Duration::from_secs(5));
+    assert!(client.probe(Duration::from_secs(1)).is_ok());
+    assert!(client.req(&RawMessage::default()).is_ok());
+}

--- a/zenoh-plugin-ros1/tests/rosmaster_test.rs
+++ b/zenoh-plugin-ros1/tests/rosmaster_test.rs
@@ -40,9 +40,11 @@ fn start_and_stop_master_and_check_connectivity() {
     });
 
     // start ros1 client
-    let ros1_client = rosrust::api::Ros::new(
-        "start_and_stop_master_and_check_connectivity_client",
+    let ros1_client = rosrust::api::Ros::new_raw(
         "http://localhost:11311/",
+        &rosrust::api::resolve::hostname(),
+        &rosrust::api::resolve::namespace(),
+        "start_and_stop_master_and_check_connectivity_client",
     )
     .unwrap();
 

--- a/zenoh-plugin-ros1/tests/service_cache_test.rs
+++ b/zenoh-plugin-ros1/tests/service_cache_test.rs
@@ -1,0 +1,181 @@
+//
+// Copyright (c) 2022 ZettaScale Technology
+//
+// This program and the accompanying materials are made available under the
+// terms of the Eclipse Public License 2.0 which is available at
+// http://www.eclipse.org/legal/epl-2.0, or the Apache License, Version 2.0
+// which is available at https://www.apache.org/licenses/LICENSE-2.0.
+//
+// SPDX-License-Identifier: EPL-2.0 OR Apache-2.0
+//
+// Contributors:
+//   ZettaScale Zenoh Team, <zenoh@zettascale.tech>
+//
+
+use rosrust::api::Topic;
+use zenoh_plugin_ros1::ros_to_zenoh_bridge::{
+    ros1_client::Ros1Client,
+    rosclient_test_helpers::wait_for_rosclient_to_connect,
+    service_cache::Ros1ServiceCache,
+    test_helpers::{BridgeChecker, IsolatedROSMaster, ROSEnvironment},
+};
+
+#[test]
+fn check_service_cache_single_node() {
+    // init and start isolated ros
+    let roscfg = IsolatedROSMaster::default();
+    let _ros_env = ROSEnvironment::new(roscfg.port.port).with_master();
+
+    // start rosclient
+    let service_node_name = "test_service_node";
+    let service_rosclient = Ros1Client::new(service_node_name, &roscfg.master_uri())
+        .expect("error creating service Ros1Client!");
+    let watching_rosclient = Ros1Client::new("watching_node", &roscfg.master_uri())
+        .expect("error creating watching Ros1Client!");
+    assert!(wait_for_rosclient_to_connect(&service_rosclient));
+    assert!(wait_for_rosclient_to_connect(&watching_rosclient));
+
+    // create shared topic
+    let shared_topic = BridgeChecker::make_topic("check_service_cache_single_node");
+
+    // create service
+    let _service = service_rosclient
+        .service::<rosrust::RawMessage, _>(&shared_topic, Ok)
+        .expect("error creating service!");
+
+    // create cache
+    let mut cache = Ros1ServiceCache::new("ros_service_cache_node", &roscfg.master_uri())
+        .expect("error creating Ros1ServiceCache");
+
+    // check that there is a proper service with one proper node in rosmaster's system state
+    let state = watching_rosclient
+        .state()
+        .expect("error getting ROS state!");
+
+    assert_eq!(state.services.len(), 1);
+    assert_eq!(state.services[0].connections.len(), 1);
+    assert_eq!(
+        state.services[0].connections[0],
+        format!("/{service_node_name}")
+    );
+
+    // resolve datatype
+    let resolved_datatype = cache
+        .resolve_datatype(shared_topic.name, service_node_name.to_string())
+        .unwrap();
+
+    assert_eq!(resolved_datatype, shared_topic.datatype);
+}
+
+#[test]
+fn check_service_cache_single_node_many_resolutions() {
+    // init and start isolated ros
+    let roscfg = IsolatedROSMaster::default();
+    let _ros_env = ROSEnvironment::new(roscfg.port.port).with_master();
+
+    // start rosclients
+    let service_node_name = "test_service_node";
+    let service_rosclient = Ros1Client::new(service_node_name, &roscfg.master_uri())
+        .expect("error creating service Ros1Client!");
+    let watching_rosclient = Ros1Client::new("watching_node", &roscfg.master_uri())
+        .expect("error creating watching Ros1Client!");
+    assert!(wait_for_rosclient_to_connect(&service_rosclient));
+    assert!(wait_for_rosclient_to_connect(&watching_rosclient));
+
+    // create shared topic
+    let shared_topic =
+        BridgeChecker::make_topic("check_service_cache_single_node_many_resolutions");
+
+    // create service
+    let _service = service_rosclient
+        .service::<rosrust::RawMessage, _>(&shared_topic, Ok)
+        .expect("error creating service!");
+
+    // create cache
+    let mut cache = Ros1ServiceCache::new("ros_service_cache_node", &roscfg.master_uri())
+        .expect("error creating Ros1ServiceCache");
+
+    // check that there is a proper service with one proper node in rosmaster's system state
+    let state = watching_rosclient
+        .state()
+        .expect("error getting ROS state!");
+
+    assert_eq!(state.services.len(), 1);
+    assert_eq!(state.services[0].connections.len(), 1);
+    assert_eq!(
+        state.services[0].connections[0],
+        format!("/{service_node_name}")
+    );
+
+    // resolve datatype many times
+    for _ in 0..10 {
+        let resolved_datatype = cache
+            .resolve_datatype(shared_topic.name.clone(), service_node_name.to_string())
+            .unwrap();
+        assert_eq!(resolved_datatype, shared_topic.datatype);
+    }
+}
+
+#[test]
+fn check_service_cache_many_nodes() {
+    // init and start isolated ros
+    let roscfg = IsolatedROSMaster::default();
+    let _ros_env = ROSEnvironment::new(roscfg.port.port).with_master();
+
+    // start rosclients
+    let service_node_name1 = "test_service_node1";
+    let service_node_name2 = "test_service_node2";
+    let service_rosclient1 = Ros1Client::new(service_node_name1, &roscfg.master_uri())
+        .expect("error creating service Ros1Client 1!");
+    let service_rosclient2 = Ros1Client::new(service_node_name2, &roscfg.master_uri())
+        .expect("error creating service Ros1Client 2!");
+    let watching_rosclient = Ros1Client::new("watching_node", &roscfg.master_uri())
+        .expect("error creating watching Ros1Client!");
+    assert!(wait_for_rosclient_to_connect(&service_rosclient1));
+    assert!(wait_for_rosclient_to_connect(&service_rosclient2));
+    assert!(wait_for_rosclient_to_connect(&watching_rosclient));
+
+    // create shared topics
+    let shared_topic1 = BridgeChecker::make_topic("check_service_cache_many_nodes");
+    let shared_topic2 = Topic {
+        name: shared_topic1.name.clone(),
+        datatype: "some/other".to_string(),
+    };
+
+    // create services
+    let _service1 = service_rosclient1
+        .service::<rosrust::RawMessage, _>(&shared_topic1, Ok)
+        .expect("error creating service 1!");
+    let _service2 = service_rosclient2
+        .service::<rosrust::RawMessage, _>(&shared_topic2, Ok)
+        .expect("error creating service 2!");
+
+    // create cache
+    let mut cache = Ros1ServiceCache::new("ros_service_cache_node", &roscfg.master_uri())
+        .expect("error creating Ros1ServiceCache");
+
+    // check that there is a proper service with one proper node in rosmaster's system state
+    // note: currently, ROS1 intends to have not more than one node for each service topic,
+    // so for current test case service2 should hide service1
+    let state = watching_rosclient
+        .state()
+        .expect("error getting ROS state!");
+    assert_eq!(state.services.len(), 1);
+    assert_eq!(state.services[0].connections.len(), 1);
+    assert_eq!(
+        state.services[0].connections[0],
+        format!("/{service_node_name2}")
+    );
+
+    // resolve datatype for service 1
+    let resolved_datatype = cache
+        .resolve_datatype(shared_topic1.name, service_node_name1.to_string())
+        .unwrap();
+    assert_eq!(resolved_datatype, shared_topic2.datatype);
+
+    // resolve datatype for service 2
+    let resolved_datatype = cache
+        .resolve_datatype(shared_topic2.name, service_node_name2.to_string())
+        .unwrap();
+    assert_eq!(resolved_datatype, shared_topic2.datatype);
+}


### PR DESCRIPTION
- fixed datatype handling
- started works for preserving datatype (need rosrust changes) 
- supported isolation patch for rosrust and added tests
- many improvements for bridging policies and command line options based on user's feedback in support
- per-topic bridging policy selection added
- enabled previously hidden release targets that caused failures