### PR TITLE
feat: exposing zenoh's stat feature

### DIFF
--- a/zenoh-plugin-ros1/Cargo.toml
+++ b/zenoh-plugin-ros1/Cargo.toml
@@ -29,6 +29,7 @@ crate-type = ["cdylib", "rlib"]
 [features]
 no_mangle = ["zenoh-plugin-trait/no_mangle"]
 test = []
+stats = ["zenoh/stats"]
 default = ["no_mangle", "test"] # TODO: https://zettascale.atlassian.net/browse/ZEN-291
 
 [dependencies]


### PR DESCRIPTION
Exposing Zenoh's `stats` feature to allow dynamic loading from a Zenoh router with stats enabled.