### PR TITLE
Remove action-rs/toolchain action

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -78,8 +78,8 @@ jobs:
         with:
           submodules: recursive
 
-      - name: Install latest Rust toolchain
-        uses: actions-rs/toolchain@v1
+      - name: Install Rust toolchain
+        run: rustup show
 
       - name: Build
         uses: actions-rs/cargo@v1


### PR DESCRIPTION
The CI testing job currently fails because of this.