### PR TITLE
fix: Set `publish = false` for zenoh-bridge-ros1

### DIFF
--- a/zenoh-bridge-ros1/Cargo.toml
+++ b/zenoh-bridge-ros1/Cargo.toml
@@ -21,6 +21,7 @@ homepage = { workspace = true }
 license = { workspace = true }
 categories = { workspace = true }
 description = "Zenoh bridge for ROS1"
+publish = false
 
 [dependencies]
 async-std = { workspace = true, features = ["unstable", "attributes"] }


### PR DESCRIPTION
Resolves https://github.com/eclipse-zenoh/ci/issues/9.