### PR TITLE
fix: Rectify plugin path in virtual manifest

### DIFF
--- a/Cargo.toml
+++ b/Cargo.toml
@@ -55,7 +55,7 @@ zenoh = { version = "0.11.0-dev", git = "https://github.com/eclipse-zenoh/zenoh.
 zenoh-ext = { version = "0.11.0-dev", git = "https://github.com/eclipse-zenoh/zenoh.git", branch = "main" }
 zenoh-core = { version = "0.11.0-dev", git = "https://github.com/eclipse-zenoh/zenoh.git", branch = "main" }
 zenoh-plugin-trait = { version = "0.11.0-dev", git = "https://github.com/eclipse-zenoh/zenoh.git", branch = "main", default-features = false }
-zenoh-plugin-ros1 = { version = "0.11.0-dev", path = "../zenoh-plugin-ros1/", default-features = false }
+zenoh-plugin-ros1 = { version = "0.11.0-dev", path = "zenoh-plugin-ros1", default-features = false }
 
 [profile.release]
 debug = false


### PR DESCRIPTION
In #37 the path to zenoh-plugin-ros1 was incorrect.