### PR TITLE
chore: renamed no_mangle feature to dynamic_plugin

### DIFF
--- a/zenoh-plugin-ros1/Cargo.toml
+++ b/zenoh-plugin-ros1/Cargo.toml
@@ -27,11 +27,11 @@ name = "zenoh_plugin_ros1"
 crate-type = ["cdylib", "rlib"]
 
 [features]
-no_mangle = []
+dynamic_plugin = []
 test = []
 stats = ["zenoh/stats"]
 default = [
-    "no_mangle",
+    "dynamic_plugin",
     "test",
 ] # TODO: https://zettascale.atlassian.net/browse/ZEN-291
 

--- a/zenoh-plugin-ros1/src/lib.rs
+++ b/zenoh-plugin-ros1/src/lib.rs
@@ -29,7 +29,7 @@ pub mod ros_to_zenoh_bridge;
 pub struct Ros1Plugin {}
 
 // declaration of the plugin's VTable for zenohd to find the plugin's functions to be called
-#[cfg(feature = "no_mangle")]
+#[cfg(feature = "dynamic_plugin")]
 zenoh_plugin_trait::declare_plugin!(Ros1Plugin);
 
 impl ZenohPlugin for Ros1Plugin {}


### PR DESCRIPTION
As suggested by @milyin this PR renames the `no_mangle` feature to `dynamic_plugin` which is easier to understand.
- Sister of: https://github.com/eclipse-zenoh/zenoh/pull/1010