### PR TITLE
Fix CI rustfmt failures

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -41,7 +41,7 @@ jobs:
           rustup component add rustfmt clippy
 
       - name: Code format check
-        run: cargo fmt --check -- --config "unstable_features=true,imports_granularity=Crate,group_imports=StdExternalCrate"
+        run: cargo fmt -p zenoh-plugin-ros1 -p zenoh-bridge-ros1 --check -- --config "unstable_features=true,imports_granularity=Crate,group_imports=StdExternalCrate"
         env:
           CARGO_REGISTRIES_CRATES_IO_PROTOCOL: sparse
 

--- a/.pre-commit-config.yaml
+++ b/.pre-commit-config.yaml
@@ -3,6 +3,6 @@ repos:
     hooks:
       - id: fmt
         name: fmt
-        entry: cargo fmt -- --config "unstable_features=true,imports_granularity=Crate,group_imports=StdExternalCrate"
+        entry: cargo fmt -p zenoh-plugin-ros1 -p zenoh-bridge-ros1 -- --config "unstable_features=true,imports_granularity=Crate,group_imports=StdExternalCrate"
         language: system
         types: [rust]


### PR DESCRIPTION
CI was failing on `cargo fmt` command checking `rosrust`  submodule.
Some new configs have been introduced with #97 , but `rosrust` was not updated accordingly.
Actually, we don't want to update `rosrust` to comply with our `rustmft` checks, since it will bring more divergence with the [original project](https://github.com/adnanademovic/rosrust).

This PR makes our `cargo fmt` command to ignore `rosrust` submodule.