### PR TITLE
chore: downgrade gh runners to ubuntu 22.04

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -28,7 +28,8 @@ jobs:
     strategy:
       fail-fast: false
       matrix:
-        os: [ubuntu-latest]
+        # Revert back to ubuntu-latest once we sort out deps
+        os: [ubuntu-22.04]
 
     steps:
       - uses: actions/checkout@v4
@@ -61,7 +62,8 @@ jobs:
     strategy:
       fail-fast: false
       matrix:
-        os: [ubuntu-latest]
+        # Revert back to ubuntu-latest once we sort out deps
+        os: [ubuntu-22.04]
 
     steps:
       - uses: actions/checkout@v4


### PR DESCRIPTION
new ubuntu-latest gh runner have a different set of packages than we expected from ubuntu 22.04