### PR TITLE
Bump Rust toolchain to 1.85

### DIFF
--- a/rust-toolchain.toml
+++ b/rust-toolchain.toml
@@ -1,2 +1,2 @@
 [toolchain]
-channel = "1.75.0"
+channel = "1.85.0"


### PR DESCRIPTION
Depends on https://github.com/eclipse-zenoh/zenoh/pull/1803

This PR simply bumps the Rust toolchain.
Given that ROS1 plugin is not in an actively maintained stated, this PR does not address all the clippy warnings that would require significant work.